### PR TITLE
[Spec Kit] Add 001-popup-reader specification and implementation plan

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/001-popup-reader"
+}

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -3,54 +3,252 @@ SPDX-FileCopyrightText: 2026 Adam Poulemanos
 
 SPDX-License-Identifier: MIT OR Apache-2.0
 -->
+<!--
+Sync Impact Report (2026-04-25)
+================================
+Version change: (template / unratified) → 1.0.0
+Bump rationale: First ratified constitution. The previous file was an
+unmodified template with placeholder principles; ratifying defined
+principles is a 0→1 event, recorded as 1.0.0 per semantic versioning.
 
-# [PROJECT_NAME] Constitution
-<!-- Example: Spec Constitution, TaskFlow Constitution, etc. -->
+Modified principles:
+- (none — initial ratification)
+
+Added principles:
+- I. Spec-Driven Development (NON-NEGOTIABLE)
+- II. Test-First Discipline (NON-NEGOTIABLE)
+- III. Unix Philosophy & Composability
+- IV. Pure-Go by Default, cgo Opt-In
+- V. Capability-Aware Graceful Degradation
+- VI. REUSE-Compliant Licensing
+
+Added sections:
+- Quality Standards
+- Development Workflow
+- Governance
+
+Removed sections:
+- (none)
+
+Templates requiring updates:
+- ✅ .specify/memory/constitution.md (this file)
+- ⚠ .specify/templates/plan-template.md — Constitution Check section
+  is a placeholder ("[Gates determined based on constitution file]"); it
+  remains generic but plans (e.g., specs/001-popup-reader/plan.md) now
+  evaluate against the principles below. No template edit needed for
+  v1.0.0; revisit if principles are renamed or reordered.
+- ⚠ .specify/templates/spec-template.md — no constitution-driven sections
+  added or removed; no edit needed.
+- ⚠ .specify/templates/tasks-template.md — no principle-specific task
+  categories required at v1.0.0; testing tasks remain optional per the
+  template's existing guidance, which is consistent with Principle II's
+  enforcement at code-review/PR gates rather than at task generation.
+- ✅ specs/001-popup-reader/plan.md — already aligned via its
+  Constitution Check stub; the stub's "no ratified constitution" note
+  becomes stale on this commit. Updating the existing plan after
+  ratification is left as a documentation TODO and does not affect
+  implementation work.
+
+Follow-up TODOs:
+- TODO(plan-001): Refresh the Constitution Check section in
+  specs/001-popup-reader/plan.md to cite this constitution by version
+  next time that plan is amended.
+
+================================
+-->
+
+# spy Constitution
+
+`spy` is a focused popup viewer for text, code, PDFs, and images, designed
+for review work in multiplexed terminal environments. This constitution
+records the non-negotiable engineering principles, quality standards, and
+governance rules that bind all contributions to the project.
 
 ## Core Principles
 
-### [PRINCIPLE_1_NAME]
-<!-- Example: I. Library-First -->
-[PRINCIPLE_1_DESCRIPTION]
-<!-- Example: Every feature starts as a standalone library; Libraries must be self-contained, independently testable, documented; Clear purpose required - no organizational-only libraries -->
+### I. Spec-Driven Development (NON-NEGOTIABLE)
 
-### [PRINCIPLE_2_NAME]
-<!-- Example: II. CLI Interface -->
-[PRINCIPLE_2_DESCRIPTION]
-<!-- Example: Every library exposes functionality via CLI; Text in/out protocol: stdin/args → stdout, errors → stderr; Support JSON + human-readable formats -->
+Every feature, behavior change, or architectural shift MUST flow through the
+spec-kit workflow before implementation begins:
 
-### [PRINCIPLE_3_NAME]
-<!-- Example: III. Test-First (NON-NEGOTIABLE) -->
-[PRINCIPLE_3_DESCRIPTION]
-<!-- Example: TDD mandatory: Tests written → User approved → Tests fail → Then implement; Red-Green-Refactor cycle strictly enforced -->
+1. `/speckit-specify` — capture user-facing requirements (no implementation detail).
+2. `/speckit-clarify` — resolve ambiguities with the requester.
+3. `/speckit-plan` — produce a Technical Context, Constitution Check,
+   research notes, data model, contracts, and quickstart.
+4. `/speckit-tasks` — break the plan into independently testable tasks.
+5. `/speckit-implement` — execute tasks; gate-check against this constitution.
 
-### [PRINCIPLE_4_NAME]
-<!-- Example: IV. Integration Testing -->
-[PRINCIPLE_4_DESCRIPTION]
-<!-- Example: Focus areas requiring integration tests: New library contract tests, Contract changes, Inter-service communication, Shared schemas -->
+**Rule**: No production code lands without a corresponding `specs/NNN-*/`
+directory containing at minimum `spec.md` and `plan.md`. Bug fixes ≤ 20
+lines and dependency-version bumps are exempt; everything else is in scope.
 
-### [PRINCIPLE_5_NAME]
-<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
-[PRINCIPLE_5_DESCRIPTION]
-<!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
+**Rationale**: The project's own DEVELOPMENT.md and existing spec-kit
+configuration already encode this expectation; making it constitutional
+prevents the "small change, skip the spec" drift that erodes the workflow.
 
-## [SECTION_2_NAME]
-<!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->
+### II. Test-First Discipline (NON-NEGOTIABLE)
 
-[SECTION_2_CONTENT]
-<!-- Example: Technology stack requirements, compliance standards, deployment policies, etc. -->
+New features and behavior changes MUST be developed test-first:
 
-## [SECTION_3_NAME]
-<!-- Example: Development Workflow, Review Process, Quality Gates, etc. -->
+- Write the failing test before the implementation; merge with the test in
+  the same change set.
+- All packages MUST have meaningful unit tests; coverage SHOULD remain at
+  or above 80 %, measured per-package.
+- `go test ./... -race` MUST pass before any commit pushed to a feature
+  branch is opened as a PR.
+- Integration tests for capability-driven paths (theme detection, graphics
+  protocols, terminal resize) MUST exercise the real path with PTYs or
+  documented stubs; mocks MAY be used only for I/O boundaries.
+- Tests SHOULD be table-driven where the cardinality of cases warrants it.
 
-[SECTION_3_CONTENT]
-<!-- Example: Code review requirements, testing gates, deployment approval process, etc. -->
+**Rationale**: The project ships a TUI that runs against a heterogeneous
+mix of terminals; regressions are easy to introduce and hard to detect by
+inspection. Test-first discipline is the cheapest defense.
+
+### III. Unix Philosophy & Composability
+
+`spy` is a CLI tool first; the popup TUI is one of several output modes:
+
+- **Errors to stderr; content to stdout.** Diagnostic messages, deprecation
+  warnings, and debug output MUST NOT mix with user-visible content.
+- **Stable exit codes.** The codes documented in `contracts/cli.md`
+  (or its successors) are part of the public contract; semantic changes
+  require a major version bump.
+- **Stdin support is a first-class input.** Any feature that accepts a file
+  path MUST also accept piped input where it makes semantic sense.
+- **Do not write to disk for transient input.** Piped content lives in
+  memory; the tool MUST NOT create temp files for stdin under normal
+  operation.
+- **Compose, do not capture.** When integrating with external tools, prefer
+  invoking via documented APIs / pipelines over scraping or wrapping.
+
+**Rationale**: The product was specified explicitly as a `bat`-like tool;
+honouring Unix conventions keeps it a good citizen of any pipeline.
+
+### IV. Pure-Go by Default, cgo Opt-In
+
+The default `go build` target MUST produce a working binary using only
+pure-Go dependencies:
+
+- Any feature that requires cgo (e.g., MuPDF rasterization via `go-fitz`)
+  MUST be guarded by a build tag and have a pure-Go fallback that
+  degrades the feature gracefully (typically falling back to text mode
+  or to a metadata block).
+- Cross-compilation to common targets (`linux/amd64`, `linux/arm64`,
+  `darwin/amd64`, `darwin/arm64`) MUST work from a single host without
+  cgo toolchains.
+- Adding a new dependency that pulls in cgo, GPL/AGPL licensing, or > 5 MB
+  of transitive code requires explicit justification in the originating
+  plan's Complexity Tracking section.
+
+**Rationale**: Distributors and users rely on `go install` and static
+binaries; making cgo opt-in preserves that contract while still allowing
+high-fidelity features where they make sense.
+
+### V. Capability-Aware Graceful Degradation
+
+`spy` runs across a wide range of terminals. The tool MUST:
+
+- Detect terminal capabilities (TTY presence, color depth, graphics
+  protocols, dimensions, background luminance) before applying behaviour
+  that depends on them.
+- Provide a working — even if reduced — experience in the absence of
+  capabilities. A 60×20 dumb terminal MUST still display content; an
+  emulator without graphics protocols MUST still display PDFs as text
+  and images as metadata blocks.
+- Never crash, hang, or corrupt terminal state because of an unsupported
+  capability. Restoring terminal state on exit (including signals and
+  panics) is mandatory.
+- Honour `NO_COLOR`, `XDG_CONFIG_HOME`, and other documented user-facing
+  environment variables.
+
+**Rationale**: The product's value disappears in any environment where it
+crashes; degradation MUST be a designed-in property, not an afterthought.
+
+### VI. REUSE-Compliant Licensing
+
+The repository is and MUST remain REUSE-compliant under the existing
+dual licence (MIT OR Apache-2.0):
+
+- Every source, configuration, documentation, and asset file MUST carry
+  a valid SPDX header (or be covered by `REUSE.toml`).
+- New dependencies MUST be license-compatible with both MIT and Apache-2.0;
+  GPL/AGPL/LGPL dependencies are forbidden in production code paths.
+- The `reuse lint` check MUST pass on `main` at all times. CI breakage
+  from licensing must be repaired before any unrelated work is merged.
+
+**Rationale**: The project has explicitly invested in REUSE compliance
+(REUSE.toml, SPDX headers, dual licence) — preserving that investment is
+a constitutional matter, not a nice-to-have.
+
+## Quality Standards
+
+- **Formatting**: `gofmt` and `goimports` MUST pass with no diff. CI hooks
+  enforce this; manual overrides are not permitted.
+- **Static analysis**: `go vet ./...` MUST pass. `staticcheck` and `gosec`
+  SHOULD pass; remaining findings MUST be triaged with a tracking
+  comment or issue.
+- **Performance budgets** (current targets, revisit per major release):
+  - First viewport frame ≤ 100 ms for ≤ 100-line files.
+  - Resident memory ≤ 500 MB at 1 GB inputs.
+  - Search across 1 MiB completes in ≤ 500 ms.
+- **Error handling**: Errors MUST be wrapped with `%w` so callers can
+  unwrap them. User-facing error messages MUST include the program name
+  prefix and a concrete cause.
+- **Documentation**: Public-facing CLI flags, env vars, exit codes, key
+  bindings, and config keys MUST be documented in the relevant
+  `specs/NNN-*/contracts/` file before they become reachable from a
+  release build.
+
+## Development Workflow
+
+- **Branching**: Feature work happens on `NNN-feature-name` branches
+  generated by `/speckit-git-feature`. Direct commits to `main` are
+  forbidden except by the constitution-amendment process below.
+- **Spec hooks**: The configured `.specify/extensions.yml` hooks govern
+  before/after-stage automation; disabling a mandatory hook for a feature
+  requires an explicit note in that feature's plan.
+- **Code review**: Every PR MUST be reviewed against this constitution.
+  PRs introducing complexity that violates a principle MUST link to the
+  Complexity Tracking entry justifying the violation.
+- **Definition of Done**: A feature is "done" when its `plan.md`'s
+  `quickstart.md` validates end-to-end on a real terminal, all tests pass
+  with `-race`, REUSE lint is clean, and the relevant `tasks.md` is
+  fully checked off (or remaining tasks are explicitly deferred with
+  rationale).
+- **Releases**: Versioning follows semver. Breaking changes to the public
+  CLI surface (flags, env vars, exit codes) require a major bump.
 
 ## Governance
-<!-- Example: Constitution supersedes all other practices; Amendments require documentation, approval, migration plan -->
 
-[GOVERNANCE_RULES]
-<!-- Example: All PRs/reviews must verify compliance; Complexity must be justified; Use [GUIDANCE_FILE] for runtime development guidance -->
+This constitution governs all contributions to the `spy` repository and
+supersedes any conflicting practice in individual PRs, agent
+instructions, or developer preferences.
 
-**Version**: [CONSTITUTION_VERSION] | **Ratified**: [RATIFICATION_DATE] | **Last Amended**: [LAST_AMENDED_DATE]
-<!-- Example: Version: 2.1.1 | Ratified: 2025-06-13 | Last Amended: 2025-07-16 -->
+**Amendment procedure**:
+
+1. Open a PR modifying `.specify/memory/constitution.md` (typically via
+   `/speckit-constitution`).
+2. Include a Sync Impact Report at the top of the file documenting
+   version change, principles affected, dependent templates updated, and
+   deferred TODOs.
+3. Apply the semver bump rules from the `/speckit-constitution` skill:
+   - **MAJOR** — backward-incompatible governance change or principle
+     removal/redefinition;
+   - **MINOR** — new principle or section added, or material expansion of
+     guidance;
+   - **PATCH** — clarifications, wording, typo fixes.
+4. Update `LAST_AMENDED_DATE` to the merge date.
+5. After merge, update dependent templates flagged in the Sync Impact
+   Report. Pending updates MUST be tracked as follow-up issues.
+
+**Compliance review**:
+
+- Every plan's "Constitution Check" section MUST cite the constitution
+  version it was evaluated against.
+- Quarterly, the maintainer SHOULD walk the most recent plans and PRs
+  against the current principles and open issues for any drift.
+- Failing a Constitution Check at planning time blocks Phase 0 research
+  unless an explicit Complexity Tracking entry justifies the deviation.
+
+**Version**: 1.0.0 | **Ratified**: 2026-04-25 | **Last Amended**: 2026-04-25

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,9 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 -->
 
 <!-- SPECKIT START -->
-For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+Active feature: `001-popup-reader`. For technologies, project structure,
+shell commands, and other planning context, read the current plan at
+[specs/001-popup-reader/plan.md](specs/001-popup-reader/plan.md). Supporting
+artifacts live alongside it: spec.md, research.md, data-model.md,
+quickstart.md, and contracts/.
 <!-- SPECKIT END -->

--- a/specs/001-popup-reader/checklists/requirements.md
+++ b/specs/001-popup-reader/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Popup Reader - Focused Text/PDF/Image Viewer
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-25  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders (can be understood by product managers)
+- [x] All mandatory sections completed (User Scenarios, Requirements, Success Criteria, Assumptions)
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous (15 functional requirements, each specific and measurable)
+- [x] Success criteria are measurable (12 criteria with specific metrics: time, file size, success rate)
+- [x] Success criteria are technology-agnostic (no mention of Go, Rust, terminal libraries, etc.)
+- [x] All acceptance scenarios are defined (22 acceptance scenarios across 6 user stories)
+- [x] Edge cases are identified (5 edge cases documented)
+- [x] Scope is clearly bounded (v1 scope, later phases noted where appropriate)
+- [x] Dependencies and assumptions identified (10 assumptions covering env, file system, scope, behavior)
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria (each FR is testable)
+- [x] User scenarios cover primary flows (6 user stories covering core use cases)
+- [x] Feature meets measurable outcomes defined in Success Criteria (12 SC items provide comprehensive validation)
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All quality checks pass. Specification is ready for `/speckit-clarify` or `/speckit-plan`
+- No clarifications needed; specification provides sufficient detail for planning phase
+- User priorities are clear (P1: text review, syntax highlighting, theming; P2: PDF/image, pipe input; P3: metadata)
+- Assumptions document reasonable defaults and scope boundaries clearly

--- a/specs/001-popup-reader/contracts/cli.md
+++ b/specs/001-popup-reader/contracts/cli.md
@@ -39,6 +39,7 @@ spy [OPTIONS] -      # explicit stdin
 | `--graphics` | | `auto`\|`none`\|`kitty`\|`iterm2`\|`sixel` | `auto` | Override graphics protocol detection. |
 | `--no-line-numbers` | | bool | false | Hide line numbers. |
 | `--no-wrap` | | bool | false | Disable soft-wrap; use horizontal scrolling instead. |
+| `--highlight-cap` | | bytes | `5242880` (5 MiB) | Disable syntax highlighting above this size. Set to `0` to disable highlighting entirely; set to a large value to force highlighting on big files (may impact SC-002). |
 | `--config` | | path | `$XDG_CONFIG_HOME/spy/config.toml` | Override config file path. |
 | `--no-config` | | bool | false | Skip loading any config file. |
 | `--debug` | | path | `""` | Write a debug log to the given file (no logging when unset). |

--- a/specs/001-popup-reader/contracts/cli.md
+++ b/specs/001-popup-reader/contracts/cli.md
@@ -68,6 +68,30 @@ Flag parsing uses Go's `flag` package conventions (`--flag=value` or
   must be a TTY); if stdout is also not a TTY, `spy` exits with the input
   copied verbatim to stdout (degenerate "cat" behavior) and exit code 0.
 
+### Resolution table when both a file argument and non-TTY stdin are present
+
+`spy` resolves source ambiguity deterministically:
+
+| `FILE` arg | `-` arg | stdin is TTY | stdout is TTY | Source used | Stdin handling |
+|------------|---------|--------------|---------------|-------------|----------------|
+| present    | no      | yes          | yes           | FILE        | ignored |
+| present    | no      | no           | yes           | FILE        | ignored (drained at exit, never read) |
+| present    | yes     | —            | yes           | usage error | exit 2 (`-` and FILE are mutually exclusive) |
+| absent     | no      | no           | yes           | stdin       | streamed |
+| absent     | no      | yes          | yes           | none        | exit 2 (usage printed) |
+| absent     | yes     | —            | yes           | stdin       | blocks on stdin until EOF/Ctrl-D |
+| absent     | no      | no           | no            | stdin       | degenerate cat to stdout, exit 0 |
+
+When a file argument is present, stdin is **never** read, even if it is
+non-TTY. This avoids a class of accidents where a piped command's output
+silently overrides an explicit file argument.
+
+### Empty input
+
+A 0-byte file or 0-byte stdin produces an alt-screen viewer showing the
+single line `(empty)` styled with `Theme.Footer`, footer reading
+`<displayname> | 0 lines | Line 0`, exit 0 on dismiss. Not an error.
+
 ## Stdout / stderr / exit codes
 
 | Stream | Use |

--- a/specs/001-popup-reader/contracts/cli.md
+++ b/specs/001-popup-reader/contracts/cli.md
@@ -1,0 +1,145 @@
+<!--
+SPDX-FileCopyrightText: 2026 Adam Poulemanos
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+# CLI Contract
+
+**Binary**: `spy`
+**Spec**: 001-popup-reader
+
+## Synopsis
+
+```text
+spy [OPTIONS] [FILE]
+spy [OPTIONS] -      # explicit stdin
+... | spy [OPTIONS]  # implicit stdin when stdin is not a TTY
+```
+
+## Positional argument
+
+| Token | Meaning |
+|-------|---------|
+| `FILE` | Path to a regular file. Symlinks are followed. Mutually exclusive with stdin. |
+| `-` | Force read from stdin even if `os.Stdin` is a TTY (will block until EOF). |
+| *(none)* | If stdin is not a TTY, read stdin. Otherwise print usage to stderr and exit 2. |
+
+## Flags
+
+| Flag | Short | Type / values | Default | Description |
+|------|-------|---------------|---------|-------------|
+| `--help` | `-h` | bool | false | Print usage on stdout, exit 0. |
+| `--version` | `-V` | bool | false | Print `spy <version>` on stdout, exit 0. |
+| `--theme` | | `auto`\|`dark`\|`light`\|`<chroma-style>` | `auto` | Override theme detection. |
+| `--vim` | | bool | false | Enable additive vim keybindings. |
+| `--lang` | `-l` | string | `""` | Force a Chroma lexer name (e.g., `go`, `python`). |
+| `--regex` | | bool | false | Treat search queries as regex by default. |
+| `--no-color` | | bool | false | Disable ANSI color (alias for `NO_COLOR=1`). |
+| `--graphics` | | `auto`\|`none`\|`kitty`\|`iterm2`\|`sixel` | `auto` | Override graphics protocol detection. |
+| `--no-line-numbers` | | bool | false | Hide line numbers. |
+| `--no-wrap` | | bool | false | Disable soft-wrap; use horizontal scrolling instead. |
+| `--config` | | path | `$XDG_CONFIG_HOME/spy/config.toml` | Override config file path. |
+| `--no-config` | | bool | false | Skip loading any config file. |
+| `--debug` | | path | `""` | Write a debug log to the given file (no logging when unset). |
+
+Flag parsing uses Go's `flag` package conventions (`--flag=value` or
+`--flag value`); both single- and double-dash forms accepted for long flags.
+
+## Environment variables
+
+| Variable | Type | Effect |
+|----------|------|--------|
+| `SPY_THEME` | `auto`\|`dark`\|`light`\|`<style>` | Same as `--theme`; flag wins. |
+| `SPY_VIM` | `0`\|`1`\|`true`\|`false` | Same as `--vim`. |
+| `SPY_GRAPHICS` | matches `--graphics` | Same as `--graphics`. |
+| `NO_COLOR` | any non-empty | Disables color (no-color.org convention). |
+| `XDG_CONFIG_HOME` | path | Config file lookup base; falls back to `$HOME/.config`. |
+| `COLORTERM` | `truecolor`\|`24bit` | Used during capability detection. |
+| `TERM`, `TERM_PROGRAM`, `LC_TERMINAL` | string | Used during capability detection. |
+| `KITTY_WINDOW_ID`, `TMUX` | string (presence) | Used during capability detection. |
+
+## Stdin behavior
+
+- Stdin is consumed only when no `FILE` is given and `os.Stdin` is not a TTY,
+  or when `-` is passed explicitly.
+- Stdin content is never persisted to disk.
+- If stdin is consumed, the alt-screen is still entered on `os.Stdout` (which
+  must be a TTY); if stdout is also not a TTY, `spy` exits with the input
+  copied verbatim to stdout (degenerate "cat" behavior) and exit code 0.
+
+## Stdout / stderr / exit codes
+
+| Stream | Use |
+|--------|-----|
+| stdout (TTY) | Alt-screen TUI frames |
+| stdout (non-TTY) | Verbatim file content (degenerate mode) |
+| stderr | All error messages, debug warnings, deprecation notes |
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success (viewer dismissed normally, or degenerate mode wrote content). |
+| `1` | Generic error not covered below. |
+| `2` | Usage error: bad flag, missing argument when stdin is a TTY, etc. |
+| `3` | I/O error: file not found, permission denied, broken symlink. |
+| `4` | Unsupported content: binary file, malformed PDF, decode failure. |
+| `5` | Terminal initialization error: no TTY when one is required. |
+| `130` | Interrupted by SIGINT. |
+| `143` | Terminated by SIGTERM. |
+
+## Error message format (stderr)
+
+Single line, prefixed with the program name (FR-013 requires errors visible to
+shell users):
+
+```text
+spy: <short reason>: <detail>
+```
+
+Examples:
+
+```text
+spy: cannot open: ./missing.txt: no such file or directory
+spy: unsupported format: ./image.heic: HEIC images are not supported
+spy: binary file: ./bin/spy: refusing to render binary content
+```
+
+## Usage output (`--help`)
+
+Stable across patch releases; backward-incompatible only with major version
+bumps. Exact format produced by Go's `flag.Usage`. Example shape:
+
+```text
+Usage: spy [OPTIONS] [FILE]
+A focused popup viewer for text, code, PDFs, and images.
+
+Options:
+  -h, --help              show this help and exit
+  -V, --version           show version and exit
+      --theme=<value>     dark|light|auto|<chroma-style>  (default: auto)
+      --vim               enable vim keybindings
+  -l, --lang=<name>       force language for highlighting
+      --regex             treat searches as regex
+      --no-color          disable color (alias for NO_COLOR=1)
+      --graphics=<value>  auto|none|kitty|iterm2|sixel    (default: auto)
+      --no-line-numbers   hide line numbers
+      --no-wrap           disable soft wrap
+      --config=<path>     config file path
+      --no-config         do not load any config file
+      --debug=<path>      write debug log to path
+
+Examples:
+  spy README.md
+  cat main.go | spy -l go
+  git diff HEAD~ | spy
+```
+
+## Compatibility notes
+
+- Flag parsing is deliberately conservative: `bat`-style short combined flags
+  (e.g., `-pP`) are not supported.
+- The contract is the *interface*, not the implementation. Internal exit codes
+  may add finer detail (e.g., `4-pdf`, `4-binary`) but the documented codes
+  remain stable.

--- a/specs/001-popup-reader/contracts/cli.md
+++ b/specs/001-popup-reader/contracts/cli.md
@@ -110,7 +110,7 @@ Exit codes:
 | `2` | Usage error: bad flag, missing argument when stdin is a TTY, etc. |
 | `3` | I/O error: file not found, permission denied, broken symlink. |
 | `4` | Unsupported content: binary file, malformed PDF, decode failure. |
-| `5` | Terminal initialization error: no TTY when one is required. |
+| `5` | Terminal setup error: stdout is not a TTY but the user explicitly requested TTY-only behavior (e.g., `--graphics` set to a non-`none` value with no TTY available, or opening `/dev/tty` for OSC probes failed). The implicit-stdin pipe path uses degenerate-cat (exit 0); the no-input + TTY-stdin path uses usage error (exit 2); exit 5 is reserved for the rare case where TTY behavior was explicitly requested. |
 | `130` | Interrupted by SIGINT. |
 | `143` | Terminated by SIGTERM. |
 
@@ -160,6 +160,29 @@ Examples:
   cat main.go | spy -l go
   git diff HEAD~ | spy
 ```
+
+## Debug log format
+
+When `--debug=<path>` is set, `spy` appends to that path one structured
+event per line as line-delimited JSON. Existing files are appended-to,
+not truncated.
+
+Schema:
+
+```json
+{"ts":"2026-04-25T12:00:00Z","level":"info","event":"capabilities","data":{"graphics":"kitty","color_depth":"truecolor","luminance":0.18}}
+{"ts":"2026-04-25T12:00:00Z","level":"warn","event":"config","data":{"unknown_key":"foo","action":"ignored"}}
+{"ts":"2026-04-25T12:00:00Z","level":"error","event":"loader","data":{"file":"x.pdf","err":"open x.pdf: no such file"}}
+```
+
+Required fields:
+
+- `ts`: RFC 3339 timestamp.
+- `level`: one of `debug` | `info` | `warn` | `error`.
+- `event`: kebab-case event name. Defined names: `capabilities`, `config`, `source`, `loader`, `highlight`, `render`, `keymap`, `signal`, `panic`.
+- `data`: object with event-specific fields.
+
+Stable across patch releases; new events may be added in minor releases. The format is part of the public contract.
 
 ## Compatibility notes
 

--- a/specs/001-popup-reader/contracts/config.md
+++ b/specs/001-popup-reader/contracts/config.md
@@ -1,0 +1,109 @@
+<!--
+SPDX-FileCopyrightText: 2026 Adam Poulemanos
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+# Config File Contract
+
+**Spec**: 001-popup-reader (Assumptions: configuration via simple file)
+**Format**: TOML
+**Default location**: `$XDG_CONFIG_HOME/spy/config.toml` (falls back to `$HOME/.config/spy/config.toml`)
+
+The config file is optional. CLI flags > env vars > config file > compiled defaults.
+
+## Schema
+
+```toml
+# All keys shown with their default values.
+
+# Theme: "auto" detects from terminal background luminance.
+theme = "auto"                      # "auto" | "dark" | "light" | "<chroma-style>"
+
+# Enable additive vim keybindings.
+vim_mode = false
+
+# Search defaults.
+regex_default = false               # treat search queries as regex by default
+case_mode = "smart"                 # "smart" | "sensitive" | "insensitive"
+
+# Display.
+word_wrap = true
+line_numbers = true
+tab_width = 4
+
+# Memory and performance limits.
+max_resident_bytes = 268435456      # 256 MiB; switch to windowed mode above this
+window_size = 8192                  # lines kept hot in windowed mode
+highlight_cap_bytes = 5242880       # 5 MiB; disable syntax highlighting above this
+
+# Graphics.
+graphics = "auto"                   # "auto" | "none" | "kitty" | "iterm2" | "sixel"
+
+# Minimum supported terminal size before degraded layout (FR clarifications Q4).
+min_cols = 80
+min_rows = 24
+
+# Custom key bindings (optional). Each value is a list of key strings.
+# Keys reference: see contracts/keys.md.
+[keys]
+# quit             = ["q", "esc", "ctrl+c"]
+# search_forward   = ["/"]
+# go_to_line       = [":"]
+
+# Per-language overrides (optional). Key is a Chroma lexer name (lowercased).
+[lang.go]
+# theme = "github"
+
+[lang.markdown]
+# word_wrap = true
+```
+
+## Validation
+
+- Unknown top-level keys: warning to stderr (or `--debug` log if set), key ignored.
+- Invalid value type or out-of-range integer: warning, default used.
+- `[keys]` table accepts only known action names; unknown actions ignored with warning.
+- `[lang.<name>]` tables accept the same keys as the top level except `[keys]`.
+- Empty file is valid; equivalent to no config file.
+
+## Examples
+
+### Minimal: prefer dark theme always
+
+```toml
+theme = "dark"
+```
+
+### Power-user: vim + regex + tighter memory
+
+```toml
+vim_mode = true
+regex_default = true
+max_resident_bytes = 67108864       # 64 MiB
+```
+
+### Per-language tuning
+
+```toml
+[lang.json]
+word_wrap = false                   # JSON is easier with horizontal scroll
+line_numbers = true
+
+[lang.markdown]
+theme = "github"
+```
+
+## Discovery rules
+
+1. If `--config <path>` is provided, load only that file (failure is a hard error, exit 2).
+2. Else, if `--no-config` is set, use compiled defaults.
+3. Else, look up `$XDG_CONFIG_HOME/spy/config.toml`, falling back to
+   `$HOME/.config/spy/config.toml`. Missing file is silently OK.
+4. After loading, env vars override matching fields; flags override env vars.
+
+## Stability
+
+The set of accepted keys is part of the public contract; new keys may be added
+in minor releases, existing keys may not be renamed or have semantics changed
+without a major version bump.

--- a/specs/001-popup-reader/contracts/internal-apis.md
+++ b/specs/001-popup-reader/contracts/internal-apis.md
@@ -97,7 +97,42 @@ var (
     ErrUnsupported    = errors.New("unsupported format")
     ErrNotFound       = errors.New("file not found")
     ErrPermission     = errors.New("permission denied")
+    ErrNotSeekable    = errors.New("source does not support seeking")
 )
+
+// LineProvider is the read-side interface the search and renderer packages
+// consume. Implemented by *loader.LineBuffer (the in-memory hot region with
+// optional windowing). Defining the interface in `source` keeps consumers
+// independent of the loader's concrete buffer type.
+type LineProvider interface {
+    // Slice returns the lines in [start, end). May trigger a paging read
+    // in windowed mode. Returns whatever is currently resident if either
+    // bound exceeds the loaded range; callers must check len(returned).
+    Slice(start, end int64) []Line
+
+    // Total returns the total line count once known, or -1 while streaming.
+    Total() int64
+}
+
+// Line and Token are defined here so all consumers (highlight, render,
+// search) depend on `source` rather than each other. Token lives in
+// `source` (not `highlight`) because a Line carries its tokens as a field;
+// the alternative (Token in highlight) would force `source → highlight`
+// and break the DAG. The Token type is intentionally agnostic to where
+// the styling came from — `highlight` populates it via Chroma, but a
+// future plain-text colorizer could produce the same shape. See
+// data-model.md for field semantics.
+type Line struct {
+    Number  int64
+    Raw     string
+    Tokens  []Token   // nil until highlighter has run
+    Wrapped []string  // cached wrap; invalidated on resize
+}
+
+type Token struct {
+    Type  chroma.TokenType  // reused from chroma; semantic styling key
+    Value string             // substring of Line.Raw
+}
 ```
 
 ## `internal/loader`
@@ -113,17 +148,21 @@ type Chunk struct {
 
 type Stream struct {
     First    Chunk             // populated synchronously before Stream is returned
-    Updates  <-chan Chunk      // subsequent chunks; closed on EOF or error
+    Updates  <-chan Chunk      // bounded buffer (cap = Config.UpdatesBuffer, default 4); closed on EOF or error
     Errs     <-chan error      // single-value channel; closed when no more errors
 }
 
 // Open begins streaming. cfg.MaxResidentBytes triggers windowed mode.
+// The Updates channel is bounded; producer blocks when full so the buffer
+// never holds more than UpdatesBuffer chunks worth of Line.Raw bytes.
+// See research.md R4 (Backpressure).
 func Open(ctx context.Context, src source.Source, cfg Config) (*Stream, error)
 
 type Config struct {
     MaxResidentBytes int64
     WindowSize       int
     InitialChunkLines int
+    UpdatesBuffer     int  // chunk channel capacity; default 4
 }
 ```
 
@@ -142,6 +181,9 @@ func New(theme *chroma.Style, depth term.ColorDepth, capBytes int64) *Highlighte
 
 // Highlight runs Chroma against a single line; if the source has no known
 // lexer, it returns the line unchanged with a single Token of type Text.
+// Token lives in `source` (not `highlight`) so source.Line.Tokens has a
+// home without forcing source → highlight; see internal-apis.md `source`
+// section.
 func (h *Highlighter) Highlight(lang string, line string) []source.Token
 
 // HighlightStream consumes chunks from in and emits chunks with Tokens
@@ -241,7 +283,24 @@ type Index struct {
     Wrapped bool
 }
 
-func Scan(ctx context.Context, lines source.LineProvider, m Matcher, dir Direction, from int64) <-chan Match
+// Scan walks lines through `provider` in `dir`, starting at `from`.
+// Emits matches on the returned channel; closes after the final match.
+// On wrap-around, emits a synthetic Match with Line == -1 as a sentinel
+// before continuing (or before close if no further matches).
+func Scan(ctx context.Context, provider source.LineProvider, m Matcher, dir Direction, from int64) <-chan Match
+
+type Direction int
+const (
+    DirForward Direction = iota
+    DirBackward
+)
+
+type CaseMode int
+const (
+    CaseSmart CaseMode = iota
+    CaseSensitive
+    CaseInsensitive
+)
 ```
 
 ## `internal/keys`

--- a/specs/001-popup-reader/contracts/internal-apis.md
+++ b/specs/001-popup-reader/contracts/internal-apis.md
@@ -179,6 +179,24 @@ type Highlighter struct { /* ... */ }
 
 func New(theme *chroma.Style, depth term.ColorDepth, capBytes int64) *Highlighter
 
+// SetCap adjusts HighlightCap at runtime; emits WarnHighlightDisabled on
+// Warns if the new cap is below the current source size.
+func (h *Highlighter) SetCap(bytes int64)
+
+// Warns is a one-shot side channel for user-visible advisories (currently:
+// "highlighting disabled (file > <cap>)"). Closed when the highlighter is
+// done. Consumers (internal/ui) surface entries in the status bar with a
+// 5 s auto-clear. Buffer 1; producer drops on full to avoid backpressure.
+type Warning struct {
+    Kind WarnKind
+    Cap  int64
+}
+type WarnKind int
+const (
+    WarnHighlightDisabled WarnKind = iota
+)
+func (h *Highlighter) Warns() <-chan Warning
+
 // Highlight runs Chroma against a single line; if the source has no known
 // lexer, it returns the line unchanged with a single Token of type Text.
 // Token lives in `source` (not `highlight`) so source.Line.Tokens has a

--- a/specs/001-popup-reader/contracts/internal-apis.md
+++ b/specs/001-popup-reader/contracts/internal-apis.md
@@ -1,0 +1,255 @@
+<!--
+SPDX-FileCopyrightText: 2026 Adam Poulemanos
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+# Internal Package APIs
+
+**Spec**: 001-popup-reader
+**Audience**: implementers; not a public Go API (modules under `internal/`).
+
+This contract pins the boundaries between internal packages so /speckit-tasks
+can parallelize work across them without accidental cross-coupling.
+
+## `internal/term`
+
+```go
+package term
+
+type ColorDepth int
+const (
+    ColorMono ColorDepth = iota
+    ColorANSI16
+    ColorANSI256
+    ColorTrueColor
+)
+
+type Graphics int
+const (
+    GraphicsNone Graphics = iota
+    GraphicsKitty
+    GraphicsITerm2
+    GraphicsSixel
+)
+
+type Capabilities struct {
+    IsTTY               bool
+    Cols, Rows          int
+    ColorDepth          ColorDepth
+    Graphics            Graphics
+    BackgroundLuminance float64 // NaN if unknown
+    Program, Term       string
+    InTmux              bool
+}
+
+// Detect probes the current process's terminal. Honors SPY_GRAPHICS,
+// SPY_THEME, NO_COLOR, COLORTERM. Probes are time-bounded (≤ 100ms total).
+func Detect(ctx context.Context) Capabilities
+
+// Restore returns a function that puts the terminal back into the state
+// captured at call time; safe to defer.
+func Restore() func()
+```
+
+Concurrency: `Detect` is goroutine-safe; `Restore`'s returned closure is
+idempotent.
+
+## `internal/source`
+
+```go
+package source
+
+type Kind int
+const (
+    KindUnknown Kind = iota
+    KindCode
+    KindMarkdown
+    KindText
+    KindPDF
+    KindImage
+    KindBinary
+)
+
+type Source interface {
+    Kind() Kind
+    DisplayName() string
+    Open() (io.ReadCloser, error) // may be called more than once for FileSource
+    Reopen() (io.ReadSeeker, error) // returns nil, ErrNotSeekable for stdin
+    Metadata() Metadata
+}
+
+type Metadata struct {
+    Path     string
+    Size     int64
+    LineCount int64
+    PageCount int
+    Modified time.Time
+    Language string
+    Encoding string
+}
+
+func FromArgs(args []string, stdin *os.File, hint string) (Source, error)
+// errors fall into:
+var (
+    ErrNoInput        = errors.New("no input provided")
+    ErrBinary         = errors.New("binary content")
+    ErrUnsupported    = errors.New("unsupported format")
+    ErrNotFound       = errors.New("file not found")
+    ErrPermission     = errors.New("permission denied")
+)
+```
+
+## `internal/loader`
+
+```go
+package loader
+
+type Chunk struct {
+    Lines     []source.Line
+    StartLine int64
+    EOF       bool
+}
+
+type Stream struct {
+    First    Chunk             // populated synchronously before Stream is returned
+    Updates  <-chan Chunk      // subsequent chunks; closed on EOF or error
+    Errs     <-chan error      // single-value channel; closed when no more errors
+}
+
+// Open begins streaming. cfg.MaxResidentBytes triggers windowed mode.
+func Open(ctx context.Context, src source.Source, cfg Config) (*Stream, error)
+
+type Config struct {
+    MaxResidentBytes int64
+    WindowSize       int
+    InitialChunkLines int
+}
+```
+
+The first chunk is sized to ≥ `cfg.InitialChunkLines` (default = 2× viewport
+height) so the first frame paints immediately. Cancellation via `ctx`
+unblocks all goroutines.
+
+## `internal/highlight`
+
+```go
+package highlight
+
+type Highlighter struct { /* ... */ }
+
+func New(theme *chroma.Style, depth term.ColorDepth, capBytes int64) *Highlighter
+
+// Highlight runs Chroma against a single line; if the source has no known
+// lexer, it returns the line unchanged with a single Token of type Text.
+func (h *Highlighter) Highlight(lang string, line string) []source.Token
+
+// HighlightStream consumes chunks from in and emits chunks with Tokens
+// populated on out. Closes out when in is closed.
+func (h *Highlighter) HighlightStream(ctx context.Context, in <-chan loader.Chunk, out chan<- loader.Chunk)
+```
+
+## `internal/graphics`
+
+```go
+package graphics
+
+// Render encodes the given image into the active graphics protocol.
+// Returns an empty string if proto == GraphicsNone.
+func Render(proto term.Graphics, img image.Image, cols, rows int) (string, error)
+
+// Cleanup emits any escape sequences needed to clear residual images
+// (e.g., Kitty "delete all images"). Idempotent.
+func Cleanup(proto term.Graphics) string
+
+// PDFPage rasterizes page n (1-indexed) of an open PDF into an image.Image.
+// Built only when the `fitz` build tag is present; the no-fitz stub returns
+// (nil, ErrPDFGraphicsUnavailable).
+func PDFPage(path string, n int, dpi float64) (image.Image, error)
+```
+
+## `internal/render`
+
+```go
+package render
+
+type Renderer interface {
+    Render(state ui.ViewerSession, viewport viewport.Model) string
+}
+
+func ForKind(k source.Kind, deps Dependencies) Renderer
+
+type Dependencies struct {
+    Theme        Theme
+    Capabilities term.Capabilities
+    Graphics     graphics.Renderer
+    Highlighter  *highlight.Highlighter
+}
+```
+
+## `internal/search`
+
+```go
+package search
+
+type Match struct { Line int64; Start, End int }
+
+func Compile(query string, regex bool, caseMode CaseMode) (Matcher, error)
+
+type Matcher interface {
+    Find(line string) []Match
+}
+
+type Index struct {
+    Matches []Match
+    Wrapped bool
+}
+
+func Scan(ctx context.Context, lines source.LineProvider, m Matcher, dir Direction, from int64) <-chan Match
+```
+
+## `internal/keys`
+
+```go
+package keys
+
+type Action string
+const (
+    ActionQuit          Action = "quit"
+    ActionScrollUp      Action = "scroll_up"
+    /* ... full list per contracts/keys.md ... */
+)
+
+type KeyMap map[Action][]key.Binding
+
+func Default() KeyMap
+func WithVim(km KeyMap) KeyMap
+func ApplyOverrides(km KeyMap, overrides map[string][]string) (KeyMap, []error)
+```
+
+## `internal/ui`
+
+```go
+package ui
+
+type Model struct { /* ViewerSession + Bubble Tea machinery */ }
+
+func NewModel(opts ModelOptions) Model
+
+type ModelOptions struct {
+    Source       source.Source
+    Stream       *loader.Stream
+    Capabilities term.Capabilities
+    Config       *config.Config
+    Theme        render.Theme
+    KeyMap       keys.KeyMap
+}
+
+// Implements tea.Model: Init, Update, View.
+```
+
+## Stability boundary
+
+These signatures are *the* boundary the implementation must respect. Internal
+implementation details (channel sizes, goroutine layout inside a package,
+private helpers) are free to change without coordination.

--- a/specs/001-popup-reader/contracts/internal-apis.md
+++ b/specs/001-popup-reader/contracts/internal-apis.md
@@ -159,8 +159,16 @@ package graphics
 func Render(proto term.Graphics, img image.Image, cols, rows int) (string, error)
 
 // Cleanup emits any escape sequences needed to clear residual images
-// (e.g., Kitty "delete all images"). Idempotent.
+// (e.g., Kitty "delete all images"). Idempotent. Returns the bytes to write;
+// the caller decides where (used for in-session cleanup via tea.Cmd, e.g.,
+// on `:open` replacing the current source).
 func Cleanup(proto term.Graphics) string
+
+// CleanupFunc returns a closure that writes the cleanup sequence directly
+// to os.Stdout. Safe to use as `defer cleanupGraphics()` in main(); fires on
+// tea.Quit, signals, AND panic — the only path that survives a cgo go-fitz
+// panic. No-op for GraphicsNone, GraphicsITerm2, GraphicsSixel. Idempotent.
+func CleanupFunc(proto term.Graphics) func()
 
 // PDFPage rasterizes page n (1-indexed) of an open PDF into an image.Image.
 // Built only when the `fitz` build tag is present; the no-fitz stub returns
@@ -173,8 +181,31 @@ func PDFPage(path string, n int, dpi float64) (image.Image, error)
 ```go
 package render
 
+// RenderContext carries the per-frame state a Renderer needs.
+// It is populated by `internal/ui` on every Update tick and passed into
+// Render(). Defining it here (rather than reaching into ui.ViewerSession)
+// keeps the dependency direction acyclic: ui → render, never render → ui.
+type RenderContext struct {
+    Buffer       *source.LineBuffer  // resident lines + windowing state
+    Viewport     viewport.Model      // scroll position + dimensions
+    Theme        Theme
+    Capabilities term.Capabilities
+    Search       search.State        // query, matches, current selection
+    Status       Status              // Idle | Loading | Streaming | Error
+    LastError    error               // populated when Status == Error
+    Page         int                 // 1-indexed; non-zero only for KindPDF
+}
+
+type Status int
+const (
+    StatusIdle Status = iota
+    StatusLoading
+    StatusStreaming
+    StatusError
+)
+
 type Renderer interface {
-    Render(state ui.ViewerSession, viewport viewport.Model) string
+    Render(ctx RenderContext) string
 }
 
 func ForKind(k source.Kind, deps Dependencies) Renderer
@@ -186,6 +217,11 @@ type Dependencies struct {
     Highlighter  *highlight.Highlighter
 }
 ```
+
+**Dependency direction**: `render` imports `source`, `term`, `graphics`,
+`highlight`, `search`, and the upstream `bubbles/viewport` type. It does NOT
+import `internal/ui`. `internal/ui` constructs a `RenderContext` from its
+`ViewerSession` on each frame and passes it in.
 
 ## `internal/search`
 

--- a/specs/001-popup-reader/contracts/internal-apis.md
+++ b/specs/001-popup-reader/contracts/internal-apis.md
@@ -74,8 +74,14 @@ const (
 type Source interface {
     Kind() Kind
     DisplayName() string
-    Open() (io.ReadCloser, error) // may be called more than once for FileSource
-    Reopen() (io.ReadSeeker, error) // returns nil, ErrNotSeekable for stdin
+    // Open returns a reader for the source bytes. FileSource may be opened
+    // multiple times (each call yields a fresh os.File). StdinSource may be
+    // opened only once; subsequent calls return (nil, ErrAlreadyConsumed).
+    Open() (io.ReadCloser, error)
+    // Reopen returns a seekable reader for windowed-mode re-reads.
+    // FileSource returns a fresh *os.File. StdinSource returns
+    // (nil, ErrNotSeekable).
+    Reopen() (io.ReadSeeker, error)
     Metadata() Metadata
 }
 
@@ -98,6 +104,7 @@ var (
     ErrNotFound       = errors.New("file not found")
     ErrPermission     = errors.New("permission denied")
     ErrNotSeekable    = errors.New("source does not support seeking")
+    ErrAlreadyConsumed = errors.New("source already consumed")
 )
 
 // LineProvider is the read-side interface the search and renderer packages

--- a/specs/001-popup-reader/contracts/internal-apis.md
+++ b/specs/001-popup-reader/contracts/internal-apis.md
@@ -163,6 +163,7 @@ type Config struct {
     WindowSize       int
     InitialChunkLines int
     UpdatesBuffer     int  // chunk channel capacity; default 4
+    MaxLineBytes      int64 // per-line truncation cap; default 102400 (100 KiB)
 }
 ```
 

--- a/specs/001-popup-reader/contracts/keys.md
+++ b/specs/001-popup-reader/contracts/keys.md
@@ -1,0 +1,112 @@
+<!--
+SPDX-FileCopyrightText: 2026 Adam Poulemanos
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+# Keybinding Contract
+
+**Spec**: 001-popup-reader (FR-005, FR-006, FR-007, FR-008)
+
+Two presets:
+
+- **Default** — arrow keys + named keys; usable without learning new bindings.
+- **Vim** — additive (`--vim` or `vim_mode=true`); default bindings remain active.
+
+Bindings render in the help overlay (`F1` / `?`) using `bubbles/key` so any
+remap automatically updates the help text.
+
+## Navigation
+
+| Action | Default | Vim addition |
+|--------|---------|--------------|
+| Scroll up one line | `↑` | `k` |
+| Scroll down one line | `↓` | `j` |
+| Scroll left one column | `←` | `h` |
+| Scroll right one column | `→` | `l` |
+| Page up | `PgUp` | `Ctrl-B` |
+| Page down | `PgDn` / `Space` | `Ctrl-F` |
+| Half page up | — | `Ctrl-U` |
+| Half page down | — | `Ctrl-D` |
+| Go to top | `Home` | `gg` |
+| Go to bottom | `End` | `G` |
+| Beginning of line | `Home` (when on line) | `0` |
+| End of line | `End` (when on line) | `$` |
+| Next page (PDF) | `]` | — |
+| Previous page (PDF) | `[` | — |
+
+## Search
+
+| Action | Default | Vim addition |
+|--------|---------|--------------|
+| Open forward search | `/` | — |
+| Open backward search | `?` | — |
+| Submit search | `Enter` | — |
+| Cancel search | `Esc` | — |
+| Next match | `n` | — |
+| Previous match | `N` | — |
+| Toggle case sensitivity (in prompt) | `\c` / `\C` | — |
+| Force regex (in prompt) | `\v` | — |
+| Force literal (in prompt) | `\V` | — |
+
+## Commands
+
+| Action | Default | Vim addition |
+|--------|---------|--------------|
+| Open command line | `:` | — |
+| Submit command | `Enter` | — |
+| Cancel command | `Esc` | — |
+| Recall previous command | `↑` (in prompt) | — |
+| Recall next command | `↓` (in prompt) | — |
+
+Commands recognised at the `:` prompt:
+
+| Command | Effect |
+|---------|--------|
+| `:N` (integer) | Jump to line `N`; clamps to last loaded line. |
+| `:0` | Jump to line 1. |
+| `:$` | Jump to last line. |
+| `:set vim` / `:set novim` | Toggle vim mode for this session. |
+| `:set theme dark|light|auto` | Switch theme. |
+| `:open <path>` | Replace current source with a new file. |
+| `:q` / `:quit` | Quit (alias of `q` / `Esc`). |
+
+Unknown commands surface a status-bar warning; they never crash the viewer.
+
+## Application
+
+| Action | Default | Vim addition |
+|--------|---------|--------------|
+| Quit | `q` / `Esc` / `Ctrl-C` | `ZZ`, `:q` |
+| Toggle help | `F1` | `?` (only outside search prompt) |
+| Open file dialog | `o` | — |
+| Reload current source | `Ctrl-R` / `r` | — |
+| Toggle line numbers | `Ctrl-L` | — |
+| Toggle word wrap | `Ctrl-W` | — |
+
+## Conflict-resolution rules
+
+- Inside a `/` / `?` search prompt: `?` is a literal character, not the help
+  toggle.
+- Inside a `:` command prompt: `:` is a literal character.
+- `Esc` always closes any active overlay before quitting; pressing `Esc` with
+  no overlay open quits.
+
+## Override
+
+A user may remap any binding via the config file:
+
+```toml
+[keys]
+quit          = ["q", "esc", "ctrl+c"]
+search_forward = ["/"]
+go_to_line    = [":"]
+```
+
+Unrecognized keys log a warning to `--debug` and are silently dropped.
+
+## Help overlay
+
+`F1` (or `?` outside a prompt) toggles a centred Lip Gloss-styled overlay
+listing the active bindings, generated from the `KeyMap`. The overlay
+respects the active theme. `Esc` or any unbound key closes it.

--- a/specs/001-popup-reader/data-model.md
+++ b/specs/001-popup-reader/data-model.md
@@ -100,7 +100,7 @@ from.
 Validation:
 
 - `FileSource.Path` must resolve to a regular file readable by the process.
-  Symlinks are followed; broken symlinks raise FR-013 stdout error.
+  Symlinks are followed; broken symlinks raise FR-013 stderr error.
 - Binary detection: first 8KiB scanned for null bytes; if > 1% of bytes are
   control characters outside `\t\r\n\x1b`, treated as binary → FR-013 error.
 - `StdinSource` is only constructed when `os.Stdin` is not a TTY.
@@ -290,8 +290,8 @@ Subset of bindings (full list in [contracts/keys.md](./contracts/keys.md)):
 
 | Rule | Source spec | Enforcement |
 |------|-------------|-------------|
-| Reject binary input with stdout error | FR-013 | `loader.Open` returns sentinel before viewer launch |
-| Reject inaccessible files with stdout error | FR-013 | `os.Stat` failure surfaces stderr message and `os.Exit(2)` |
+| Reject binary input with stderr error | FR-013 | `loader.Open` returns sentinel before viewer launch; `cmd/spy/main.go` emits `spy: binary file: …` to stderr and exits 4 |
+| Reject inaccessible files with stderr error | FR-013 | `os.Stat` failure surfaces stderr message and `os.Exit(3)` (I/O error per `contracts/cli.md`) |
 | Restore terminal on signal | FR-015 | `defer term.Restore` in `main`; Bubble Tea's signal handlers |
 | Resize handling | FR-014 | `tea.WindowSizeMsg` → viewport `SetWidth/Height` and wrapped-line cache invalidated |
 | Minimum terminal `80 × 24` | Q4 / Assumptions | Below threshold: hide footer, single-column status, no graphics; never error |

--- a/specs/001-popup-reader/data-model.md
+++ b/specs/001-popup-reader/data-model.md
@@ -18,15 +18,23 @@ columns and are produced during /speckit-implement.
 | Type group | Package |
 |------------|---------|
 | Capabilities, theme detection | `internal/term` |
-| Source / loader / chunked reader | `internal/loader` |
-| File detection, file metadata | `internal/source` |
-| Tokens, highlighter | `internal/highlight` |
+| Chunked reader, windowed buffer | `internal/loader` |
+| Source detection, metadata, **Line, Token, LineProvider** | `internal/source` |
+| Highlighter (Chroma wrapper) | `internal/highlight` |
 | Image / PDF rasterization, graphics protocols | `internal/graphics` |
-| Renderer (text, code, image, PDF) | `internal/render` |
+| Renderer (text, code, image, PDF), **RenderContext, Status, Theme** | `internal/render` |
 | Bubble Tea model + viewport | `internal/ui` |
 | Config | `internal/config` |
-| Search state | `internal/search` |
+| Search state, matcher | `internal/search` |
 | Key bindings | `internal/keys` |
+
+**Type-home rationale**: `Token` lives in `source` (not `highlight`) because
+`source.Line.Tokens` is a field; placing Token in `highlight` would force
+`source → highlight` and break the acyclic DAG. The Token type is agnostic
+to its producer — `highlight` populates it via Chroma, but a future
+non-Chroma colorizer could populate the same shape. `Status` and
+`RenderContext` live in `render` for the dual reason (avoids
+`render → ui` cycle); see `contracts/internal-apis.md`.
 
 The existing skeleton's `internal/reader` and `internal/renderer` are renamed
 for clarity (`source` and `render`) and split into the additional packages

--- a/specs/001-popup-reader/data-model.md
+++ b/specs/001-popup-reader/data-model.md
@@ -1,0 +1,286 @@
+<!--
+SPDX-FileCopyrightText: 2026 Adam Poulemanos
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+# Data Model: Popup Reader
+
+**Feature**: 001-popup-reader
+**Date**: 2026-04-25
+
+This document captures the runtime data model. Types are described
+language-agnostically; concrete Go declarations live in the linked package
+columns and are produced during /speckit-implement.
+
+## Package map (Go)
+
+| Type group | Package |
+|------------|---------|
+| Capabilities, theme detection | `internal/term` |
+| Source / loader / chunked reader | `internal/loader` |
+| File detection, file metadata | `internal/source` |
+| Tokens, highlighter | `internal/highlight` |
+| Image / PDF rasterization, graphics protocols | `internal/graphics` |
+| Renderer (text, code, image, PDF) | `internal/render` |
+| Bubble Tea model + viewport | `internal/ui` |
+| Config | `internal/config` |
+| Search state | `internal/search` |
+| Key bindings | `internal/keys` |
+
+The existing skeleton's `internal/reader` and `internal/renderer` are renamed
+for clarity (`source` and `render`) and split into the additional packages
+listed above as functionality is added; this is a /speckit-tasks concern.
+
+---
+
+## Entities
+
+### ViewerSession
+
+Top-level state held by the Bubble Tea model. There is exactly one per
+process invocation.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Source` | `Source` | The thing we're displaying — file or stdin. |
+| `Buffer` | `*LineBuffer` | Resident lines + windowing state. |
+| `Renderer` | `Renderer` | Strategy chosen by source kind + capabilities. |
+| `Viewport` | `bubbles/viewport.Model` | Scroll position, content, dimensions. |
+| `Capabilities` | `TerminalCapabilities` | Frozen at startup; refreshed on resize for size only. |
+| `Theme` | `Theme` | `dark` / `light`; auto-detected unless overridden. |
+| `KeyMap` | `KeyMap` | Active bindings (default ± vim). |
+| `Search` | `SearchState` | Inactive when `Query == ""`. |
+| `CommandLine` | `CommandLineState` | `:` / `/` / `?` prompt buffer. |
+| `Config` | `*Config` | Snapshot of resolved config (CLI > env > file > defaults). |
+| `Status` | `Status` | Idle / Loading / Streaming / Error. |
+| `LastError` | `error` | Set when `Status == Error`; rendered in status bar. |
+| `Quitting` | `bool` | Set true by `tea.Quit`; final frame uses it. |
+
+**Lifecycle**:
+
+```text
+NEW → READY → STREAMING ⇄ READY → QUITTING
+              ↘            ↗
+                ERROR  ─────
+```
+
+Transitions:
+
+- `NEW → READY`: initial chunk received from the loader; first frame paints.
+- `READY → STREAMING`: indicator shown when user scrolls past loaded region.
+- `STREAMING → READY`: loader catches up; indicator clears.
+- `_ → ERROR`: loader emits unrecoverable error (rare — most errors short-circuit before the viewer launches per FR-013).
+- `_ → QUITTING`: q / Esc / SIGINT.
+
+---
+
+### Source
+
+Tagged union (Go: interface + concrete types) describing where bytes come
+from.
+
+| Variant | Fields |
+|---------|--------|
+| `FileSource` | `Path string`, `Size int64`, `ModTime time.Time`, `Detected FileKind` |
+| `StdinSource` | `LangHint string` (from `--lang` or `\#!shebang` sniff), `Detected FileKind` |
+
+Validation:
+
+- `FileSource.Path` must resolve to a regular file readable by the process.
+  Symlinks are followed; broken symlinks raise FR-013 stdout error.
+- Binary detection: first 8KiB scanned for null bytes; if > 1% of bytes are
+  control characters outside `\t\r\n\x1b`, treated as binary → FR-013 error.
+- `StdinSource` is only constructed when `os.Stdin` is not a TTY.
+
+---
+
+### FileKind
+
+Enumeration; drives renderer selection.
+
+| Value | Detection trigger |
+|-------|-------------------|
+| `Code` | Extension in known set, or Chroma `lexers.Match` succeeds |
+| `Markdown` | Extension `.md`, `.markdown`, `.mdx` |
+| `Text` | All other UTF-8/ASCII content |
+| `PDF` | Extension `.pdf`, magic bytes `%PDF-` |
+| `Image` | Extension in `.png/.jpg/.jpeg/.gif/.bmp/.webp` |
+| `Binary` | Any other byte content (rejected → FR-013) |
+| `Unknown` | Pre-detection state only |
+
+---
+
+### FileMetadata
+
+Returned alongside content; rendered in the footer per FR-009.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `DisplayName` | `string` | `basename(Path)` for files, `<stdin>` for pipes. |
+| `Kind` | `FileKind` | |
+| `Language` | `string` | Chroma lexer name (e.g., `Go`, `Python`) or `""`. |
+| `Size` | `int64` | Bytes; `-1` if unknown (stdin streaming). |
+| `LineCount` | `int64` | `-1` if still streaming. |
+| `Modified` | `time.Time` | Zero value for stdin. |
+| `PageCount` | `int` | Non-zero for PDFs. |
+| `Encoding` | `string` | `utf-8` / `latin-1` / `unknown`. |
+
+---
+
+### LineBuffer
+
+Resident-line storage with optional windowing.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Lines` | `[]Line` | Hot region. |
+| `BaseLineNumber` | `int64` | First line number stored in `Lines`. |
+| `Total` | `int64` | Total line count once known; `-1` while streaming. |
+| `Windowed` | `bool` | True when input exceeds `MaxResidentBytes`. |
+| `WindowSize` | `int` | Lines kept hot (default 8192). |
+| `Source` | `io.ReadSeeker` | Set when `Windowed`; nil for stdin. |
+| `Append(lines []Line)` | method | Used by loader chunks. |
+| `Slice(start, end int64) []Line` | method | Renderer access; may trigger a paging read in windowed mode. |
+
+Invariants:
+
+- `len(Lines) ≤ WindowSize` whenever `Windowed`.
+- `BaseLineNumber + len(Lines) ≤ Total` once `Total ≥ 0`.
+
+---
+
+### Line
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Number` | `int64` | 1-indexed for display. |
+| `Raw` | `string` | Pre-tokenized text without trailing `\n`. |
+| `Tokens` | `[]Token` | Nil until highlighter has run; `Renderer` falls back to `Raw`. |
+| `Wrapped` | `[]string` | Cached wrap if `WordWrap == true`; invalidated on resize. |
+
+---
+
+### Token
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Type` | `chroma.TokenType` | Reused from Chroma. |
+| `Value` | `string` | Substring of `Raw`. |
+
+---
+
+### TerminalCapabilities
+
+Snapshot taken at startup; the `Cols`/`Rows` fields update on resize.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `IsTTY` | `bool` | Stdout is a terminal. |
+| `Cols`, `Rows` | `int` | Terminal dimensions. |
+| `ColorDepth` | `ColorDepth` | `Mono`, `ANSI16`, `ANSI256`, `TrueColor`. |
+| `Graphics` | `GraphicsProtocol` | `None`, `Kitty`, `ITerm2`, `Sixel`. |
+| `BackgroundLuminance` | `float64` | 0..1; ≥ 0.5 → light. NaN if unknown. |
+| `Program` | `string` | `TERM_PROGRAM` value. |
+| `Term` | `string` | `TERM` value. |
+| `InTmux` | `bool` | True if `TMUX` env set. |
+
+---
+
+### Theme
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Name` | `string` | One of `dark`, `light`, or a Chroma style name. |
+| `ChromaStyle` | `*chroma.Style` | Resolved style; `dark` → `monokai` default, `light` → `github` default. |
+| `Statusbar` | `lipgloss.Style` | |
+| `Footer` | `lipgloss.Style` | |
+| `LineNumber` | `lipgloss.Style` | |
+| `SearchHit` | `lipgloss.Style` | |
+| `SearchActive` | `lipgloss.Style` | Currently selected match. |
+| `Error` | `lipgloss.Style` | |
+
+---
+
+### Config
+
+Resolved configuration. Defaults shown; CLI/env/file override in that order.
+
+| Field | Type | Default |
+|-------|------|---------|
+| `Theme` | `string` | `auto` |
+| `Vim` | `bool` | `false` |
+| `Regex` | `bool` | `false` |
+| `WordWrap` | `bool` | `true` |
+| `LineNumbers` | `bool` | `true` |
+| `TabWidth` | `int` | `4` |
+| `MaxResidentBytes` | `int64` | `268435456` (256 MiB) |
+| `WindowSize` | `int` | `8192` |
+| `HighlightCap` | `int64` | `5242880` (5 MiB) |
+| `Graphics` | `string` | `auto` |
+| `LangHint` | `string` | `""` |
+| `NoColor` | `bool` | `false` (auto-true if `NO_COLOR` set) |
+| `MinCols`, `MinRows` | `int` | `80`, `24` (degraded layout below) |
+
+---
+
+### KeyMap
+
+Subset of bindings (full list in [contracts/keys.md](./contracts/keys.md)):
+
+| Action | Default | Vim addition |
+|--------|---------|--------------|
+| Quit | `q`, `Esc`, `Ctrl-C` | — |
+| ScrollUp / Down | `↑` / `↓` | `k` / `j` |
+| ScrollLeft / Right | `←` / `→` | `h` / `l` |
+| PageUp / Down | `PgUp` / `PgDn` | `Ctrl-B` / `Ctrl-F` |
+| HalfPageUp / Down | — | `Ctrl-U` / `Ctrl-D` |
+| Home / End | `Home` / `End` | `gg` / `G`, `0` / `$` |
+| SearchForward | `/` | — |
+| SearchBackward | `?` | — |
+| NextMatch / PrevMatch | `n` / `N` | — |
+| GoToLine | `:` | — |
+| ToggleHelp | `F1` | `?` (when not in search) |
+| OpenFile | `o` | — |
+
+---
+
+### SearchState
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Query` | `string` | Empty when inactive. |
+| `Direction` | `enum{Forward, Backward}` | |
+| `Regex` | `bool` | Per-search override of config. |
+| `CaseMode` | `enum{Smart, Sensitive, Insensitive}` | |
+| `Matches` | `[]Match` | Computed on-demand or eagerly for small files. |
+| `CurrentMatch` | `int` | -1 if no match selected. |
+| `Wrapped` | `bool` | Latest navigation wrapped around. |
+| `Pending` | `bool` | True while a background scan is running. |
+
+`Match` is `{Line int64, Start, End int}`.
+
+---
+
+### CommandLineState
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Active` | `bool` | True while `:` / `/` / `?` prompt is open. |
+| `Prefix` | `rune` | One of `:`, `/`, `?`. |
+| `Buffer` | `string` | Current input. |
+| `History` | `[]string` | Per-session, oldest-first. |
+| `HistoryCursor` | `int` | -1 = current input; ≥0 = from history. |
+
+---
+
+## Cross-cutting validation rules
+
+| Rule | Source spec | Enforcement |
+|------|-------------|-------------|
+| Reject binary input with stdout error | FR-013 | `loader.Open` returns sentinel before viewer launch |
+| Reject inaccessible files with stdout error | FR-013 | `os.Stat` failure surfaces stderr message and `os.Exit(2)` |
+| Restore terminal on signal | FR-015 | `defer term.Restore` in `main`; Bubble Tea's signal handlers |
+| Resize handling | FR-014 | `tea.WindowSizeMsg` → viewport `SetWidth/Height` and wrapped-line cache invalidated |
+| Minimum terminal `80 × 24` | Q4 / Assumptions | Below threshold: hide footer, single-column status, no graphics; never error |
+| Stdin not retained on disk | Assumption | `LineBuffer.Source` is nil for stdin; windowing falls back to "scroll forward only" with a warning |

--- a/specs/001-popup-reader/data-model.md
+++ b/specs/001-popup-reader/data-model.md
@@ -53,9 +53,13 @@ process invocation.
 | `Search` | `SearchState` | Inactive when `Query == ""`. |
 | `CommandLine` | `CommandLineState` | `:` / `/` / `?` prompt buffer. |
 | `Config` | `*Config` | Snapshot of resolved config (CLI > env > file > defaults). |
-| `Status` | `Status` | Idle / Loading / Streaming / Error. |
+| `Status` | `render.Status` | Idle / Loading / Streaming / Error. Defined in `internal/render` so renderers can consume it without an `internal/ui` import. |
 | `LastError` | `error` | Set when `Status == Error`; rendered in status bar. |
 | `Quitting` | `bool` | Set true by `tea.Quit`; final frame uses it. |
+
+**Renderer integration**: `ui.Model.View` builds a `render.RenderContext`
+(see `contracts/internal-apis.md`) from the fields above on every frame and
+calls `Renderer.Render(ctx)`. The renderer never imports `internal/ui`.
 
 **Lifecycle**:
 

--- a/specs/001-popup-reader/plan.md
+++ b/specs/001-popup-reader/plan.md
@@ -1,0 +1,268 @@
+<!--
+SPDX-FileCopyrightText: 2026 Adam Poulemanos
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+# Implementation Plan: Popup Reader
+
+**Branch**: `001-popup-reader` | **Date**: 2026-04-25 | **Spec**: [./spec.md](./spec.md)
+**Input**: [specs/001-popup-reader/spec.md](./spec.md)
+
+## Summary
+
+`spy` is a focused popup viewer for text, code, PDFs, and images, optimised
+for review work inside multiplexed terminals (tmux and friends). The MVP
+covers six prioritised user stories: quick text review with syntax
+highlighting (P1), code navigation/search (P1), dark/light theme adaptation
+(P1), inline PDF/image rendering on capable terminals with graceful fallback
+(P2), pipe-input support à la `bat` (P2), and footer metadata (P3).
+
+The implementation extends the existing Bubble Tea + Lip Gloss + Chroma +
+pdfcpu skeleton with concurrent progressive loading, capability-driven
+graphics protocols (Kitty / iTerm2 / sixel), OSC-11 theme detection, smart
+search, and a layered config loader (TOML + env + flags). Errors are emitted
+to stderr without launching the viewer. Stdin and very large files share a
+single chunked-loader pipeline with optional windowing for files above
+256 MiB to honour the 500 MB working-set ceiling.
+
+Detailed unknowns and decisions live in [./research.md](./research.md);
+runtime types in [./data-model.md](./data-model.md); user-facing and
+internal API contracts in [./contracts/](./contracts/); validation walk-through
+in [./quickstart.md](./quickstart.md).
+
+## Technical Context
+
+**Language/Version**: Go 1.26.2 (per `go.mod`).
+**Primary Dependencies**:
+
+- `github.com/charmbracelet/bubbletea` — TUI runtime.
+- `github.com/charmbracelet/bubbles/viewport` — scrollable region (replacing the current hand-rolled viewport).
+- `github.com/charmbracelet/lipgloss` — terminal styling.
+- `github.com/charmbracelet/glamour` — markdown rendering.
+- `github.com/alecthomas/chroma/v2` — syntax highlighting.
+- `github.com/pdfcpu/pdfcpu` — PDF metadata + text extraction (already vendored).
+- `github.com/gen2brain/go-fitz` — PDF rasterization (cgo; gated by `fitz` build tag).
+- `github.com/mattn/go-sixel` — sixel encoding for terminals that support it.
+- `github.com/muesli/termenv` — already transitive; used for OSC-11 background detection.
+- `github.com/BurntSushi/toml` — config-file parser.
+- `golang.org/x/term` — TTY detection and terminal-state save/restore.
+
+**Storage**: None (read-only viewer). Optional config file at
+`$XDG_CONFIG_HOME/spy/config.toml`; no other persistent state.
+
+**Testing**: `go test ./... -race -cover`, table-driven tests, plus a
+`tests/integration` harness using `golang.org/x/term` PTY helpers and a
+golden-file output check for renderer output. Quickstart-style end-to-end
+flows captured as scripted shell tests under `tests/e2e`.
+
+**Target Platform**: Linux and macOS terminals (xterm-compatible). Windows
+via `windows-1252` codepage detection out of scope for v1; binary build
+should still compile under `GOOS=windows` but graphics protocols are
+disabled.
+
+**Project Type**: CLI / desktop-app. Single Go module; no front/back split.
+
+**Performance Goals**:
+
+- ≤ 100 ms time-to-first-frame for ≤ 100-line files (SC-001).
+- 60 fps perceived smoothness while scrolling 10k-line files (SC-002).
+- ≤ 500 ms search across files up to 1 MiB (SC-003).
+- Resident memory ≤ 500 MB on 1 GB inputs (SC-005).
+
+**Constraints**:
+
+- Pure-Go default build; cgo-using features (PDF rasterization) gated behind
+  `fitz` build tag so static-binary distros can opt out.
+- Reuse-compliant licensing already in place; new files MUST carry SPDX
+  headers (MIT OR Apache-2.0).
+- No telemetry or network calls.
+
+**Scale/Scope**: Single-user, single-process; one viewer session per
+invocation. Up to ~1 GB inputs via windowed mode. Config file ≤ a few KiB.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The project's `.specify/memory/constitution.md` is an unmodified template
+(`[PROJECT_NAME] Constitution`, all principles still placeholders). The
+`/speckit-constitution` workflow has not been run, so there are no ratified
+principles to gate against.
+
+This plan instead aligns with the user's global Go rules
+(`~/.claude/rules/golang/*` — coding-style, testing, security, hooks,
+patterns) and the existing in-repo `DEVELOPMENT.md`. Specifically:
+
+| Default principle (from rules) | Plan compliance |
+|--------------------------------|-----------------|
+| Accept interfaces, return structs | Honored: `source.Source`, `render.Renderer`, `keys.Action` boundaries. |
+| Wrap errors with `%w` | Honored throughout the loader / source / graphics layers. |
+| Run with `-race`, table-driven tests, ≥ 80 % coverage | Adopted as testing baseline. |
+| `gofmt`/`goimports` mandatory | Hooks already configured globally. |
+| Functional options for constructors | Used for `term.Detect(opts...)`, `loader.Open(...)`. |
+| Honor `NO_COLOR` and OSC standards | Wired in `term` and `render` packages. |
+| Reuse-compliant SPDX headers | All new files MUST carry the existing dual-license header. |
+| No cgo unless gated | `go-fitz` is the only cgo dep; behind `fitz` build tag. |
+
+Constitution gate result: **PASS (with note)** — proceed; raise an issue to
+run `/speckit-constitution` before the next feature so future plans gate
+against ratified principles.
+
+Re-evaluation after Phase 1 design: **PASS (no new violations)**. The
+contracts in `contracts/internal-apis.md` keep cross-package dependencies
+acyclic (`term` → leaf; `source` → `term`; `loader` → `source`;
+`highlight` → `source`; `graphics` → `term`; `render` → all of the above;
+`ui` → `render` + `keys`).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-popup-reader/
+├── plan.md              # This file (/speckit-plan output)
+├── spec.md              # /speckit-specify + /speckit-clarify output
+├── research.md          # Phase 0
+├── data-model.md        # Phase 1
+├── quickstart.md        # Phase 1
+├── contracts/
+│   ├── cli.md           # CLI surface
+│   ├── keys.md          # Key bindings
+│   ├── config.md        # Config file schema
+│   └── internal-apis.md # Internal package signatures
+├── checklists/
+│   └── requirements.md  # /speckit-specify output
+└── tasks.md             # /speckit-tasks output (NOT created here)
+```
+
+### Source Code (repository root)
+
+The existing layout (`cmd/spy` + `internal/{config,reader,renderer,ui}`) is
+extended into the structure below. Renames are deliberate to align with the
+package boundaries pinned in [contracts/internal-apis.md](./contracts/internal-apis.md).
+The current `internal/reader` becomes `internal/source`, and
+`internal/renderer` becomes `internal/render` to free those names for the
+new chunked-loader and capability-aware renderer respectively. /speckit-tasks
+will produce migration tasks; this plan documents the destination shape.
+
+```text
+spy/
+├── cmd/
+│   └── spy/
+│       ├── main.go              # Flag parsing, capability probe, wiring
+│       └── flags.go             # Flag/env definitions; pure (testable)
+├── internal/
+│   ├── config/                  # Existing; expanded with TOML loader, XDG lookup
+│   │   ├── config.go
+│   │   ├── load.go              # TOML + env + flag merge
+│   │   └── load_test.go
+│   ├── term/                    # NEW: TTY + capability detection + restore
+│   │   ├── capabilities.go
+│   │   ├── theme.go             # OSC 11 luminance probe
+│   │   └── *_test.go
+│   ├── source/                  # RENAMED from reader; concept of Source / Kind / Metadata
+│   │   ├── source.go
+│   │   ├── file.go
+│   │   ├── stdin.go
+│   │   ├── detect.go
+│   │   └── *_test.go
+│   ├── loader/                  # NEW: chunked + windowed reader, goroutine pipeline
+│   │   ├── stream.go
+│   │   ├── window.go
+│   │   └── *_test.go
+│   ├── highlight/               # NEW: Chroma streaming highlighter
+│   │   ├── highlighter.go
+│   │   └── *_test.go
+│   ├── graphics/                # NEW: image / PDF graphics protocols
+│   │   ├── kitty.go
+│   │   ├── iterm2.go
+│   │   ├── sixel.go
+│   │   ├── pdf_fitz.go          # build tag: fitz
+│   │   ├── pdf_nofitz.go        # build tag: !fitz
+│   │   └── *_test.go
+│   ├── render/                  # RENAMED from renderer; per-Kind renderers
+│   │   ├── renderer.go
+│   │   ├── code.go
+│   │   ├── markdown.go
+│   │   ├── image.go
+│   │   ├── pdf.go
+│   │   ├── theme.go
+│   │   ├── statusbar.go
+│   │   └── *_test.go
+│   ├── search/                  # NEW
+│   │   ├── search.go
+│   │   ├── matcher.go
+│   │   └── *_test.go
+│   ├── keys/                    # NEW
+│   │   ├── keymap.go
+│   │   ├── default.go
+│   │   ├── vim.go
+│   │   └── *_test.go
+│   └── ui/                      # Existing; rewired to use new packages
+│       ├── model.go
+│       ├── update.go
+│       ├── view.go
+│       ├── help.go
+│       └── *_test.go
+├── tests/
+│   ├── integration/             # PTY-driven tests covering capability paths
+│   └── e2e/                     # Scripted shell flows mirroring quickstart.md
+├── examples/
+│   └── config.toml              # Reference config matching contracts/config.md
+├── DEVELOPMENT.md
+├── README.md
+├── Makefile
+├── REUSE.toml
+├── _typos.toml
+├── go.mod
+└── go.sum
+```
+
+**Structure Decision**: Keep the existing single-module CLI layout. The new
+features are accommodated by splitting `internal/reader` and
+`internal/renderer` into purpose-specific packages (`term`, `source`,
+`loader`, `highlight`, `graphics`, `render`, `search`, `keys`), preserving a
+DAG of dependencies and matching the contract in
+[contracts/internal-apis.md](./contracts/internal-apis.md). All production
+code stays under `internal/` so we retain freedom to reshape package
+boundaries before any external API stabilises.
+
+## Phase 0: Outline & Research
+
+Output: [./research.md](./research.md).
+
+Resolved 13 unknowns covering capability detection, image protocols, PDF
+preview strategy, progressive loading, stdin handling, theme detection,
+streaming highlighting, search/jump UX, viewport choice, signal handling,
+configuration loading, key-binding model, and the constitution-template gap.
+
+All `NEEDS CLARIFICATION` items from the spec's clarification phase were
+already resolved into FR-005, FR-012, FR-013, and the Q4 minimum-size
+assumption; Phase 0 surfaced no further unresolved ambiguities.
+
+## Phase 1: Design & Contracts
+
+Outputs:
+
+- [./data-model.md](./data-model.md) — runtime entities and validation rules.
+- [./contracts/cli.md](./contracts/cli.md) — CLI surface (positional, flags,
+  env, exit codes, error formatting).
+- [./contracts/keys.md](./contracts/keys.md) — key bindings (default + vim).
+- [./contracts/config.md](./contracts/config.md) — TOML config schema.
+- [./contracts/internal-apis.md](./contracts/internal-apis.md) — internal
+  package signatures for parallel /speckit-tasks work.
+- [./quickstart.md](./quickstart.md) — 15-step end-to-end validation.
+
+Agent context update: `CLAUDE.md`'s SPECKIT marker now references
+`specs/001-popup-reader/plan.md` so future agent sessions on this branch
+load the correct plan first.
+
+## Complexity Tracking
+
+The constitution check was a non-blocking PASS (template not yet ratified),
+so no complexity-tracking entries are required. The only deliberately added
+complexity is the `fitz` build-tag gate around PDF rasterization, which is
+justified by the AGPL-vs-MIT licensing constraint on alternatives and the
+need to preserve cgo-free static builds for distributors. This is recorded
+in research §R3 rather than as a constitution violation.

--- a/specs/001-popup-reader/plan.md
+++ b/specs/001-popup-reader/plan.md
@@ -85,35 +85,22 @@ invocation. Up to ~1 GB inputs via windowed mode. Config file ≤ a few KiB.
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-The project's `.specify/memory/constitution.md` is an unmodified template
-(`[PROJECT_NAME] Constitution`, all principles still placeholders). The
-`/speckit-constitution` workflow has not been run, so there are no ratified
-principles to gate against.
+**Constitution version evaluated**: v1.0.0 (ratified 2026-04-25). Principles I–VI.
 
-This plan instead aligns with the user's global Go rules
-(`~/.claude/rules/golang/*` — coding-style, testing, security, hooks,
-patterns) and the existing in-repo `DEVELOPMENT.md`. Specifically:
+| Principle | Plan compliance |
+|-----------|-----------------|
+| I. Spec-Driven Development (NON-NEGOTIABLE) | This plan plus `spec.md`, `research.md`, `data-model.md`, `contracts/`, and `tasks.md` together satisfy the workflow. |
+| II. Test-First Discipline (NON-NEGOTIABLE) | `tasks.md` preamble enforces failing-test-first per implementation task; `-race` and ≥ 80 % per-package coverage are PR gates (T003, T111). PTY harness for capability paths (T004). |
+| III. Unix Philosophy & Composability | Errors → stderr (FR-013, `contracts/cli.md`); stable documented exit codes; stdin is first-class (FR-002, US5); no temp files for piped input (research R5); composes via flags/pipes only. |
+| IV. Pure-Go by Default, cgo Opt-In | Default build is pure-Go (T001); cgo features (`go-fitz` PDF rasterization) gated behind the `fitz` build tag with a pure-Go text-extraction fallback (research R3, T079). Cross-compile targets supported without a cgo toolchain. |
+| V. Capability-Aware Graceful Degradation | `internal/term.Detect` covers TTY/color/graphics/luminance probes (T011–T014, T064–T065); image/PDF metadata fallback (T080–T081); 80×24 graceful degradation (Q4, T098); panic-safe terminal restore + graphics cleanup (research R10, T032/T083). |
+| VI. REUSE-Compliant Licensing | Every new file carries the SPDX dual-license header (T002, T107); `reuse lint` is a CI gate (T003, T111). No GPL/AGPL transitive deps in production paths. |
 
-| Default principle (from rules) | Plan compliance |
-|--------------------------------|-----------------|
-| Accept interfaces, return structs | Honored: `source.Source`, `render.Renderer`, `keys.Action` boundaries. |
-| Wrap errors with `%w` | Honored throughout the loader / source / graphics layers. |
-| Run with `-race`, table-driven tests, ≥ 80 % coverage | Adopted as testing baseline. |
-| `gofmt`/`goimports` mandatory | Hooks already configured globally. |
-| Functional options for constructors | Used for `term.Detect(opts...)`, `loader.Open(...)`. |
-| Honor `NO_COLOR` and OSC standards | Wired in `term` and `render` packages. |
-| Reuse-compliant SPDX headers | All new files MUST carry the existing dual-license header. |
-| No cgo unless gated | `go-fitz` is the only cgo dep; behind `fitz` build tag. |
+**Constitution gate result**: **PASS** — all six principles satisfied by the artifacts in this directory.
 
-Constitution gate result: **PASS (with note)** — proceed; raise an issue to
-run `/speckit-constitution` before the next feature so future plans gate
-against ratified principles.
+**Re-evaluation after Phase 1 design**: **PASS (no new violations)**. The contracts in `contracts/internal-apis.md` keep cross-package dependencies acyclic (`term` → leaf; `source` → `term`; `loader` → `source`; `highlight` → `source`; `graphics` → `term`; `render` → all of the above; `ui` → `render` + `keys`).
 
-Re-evaluation after Phase 1 design: **PASS (no new violations)**. The
-contracts in `contracts/internal-apis.md` keep cross-package dependencies
-acyclic (`term` → leaf; `source` → `term`; `loader` → `source`;
-`highlight` → `source`; `graphics` → `term`; `render` → all of the above;
-`ui` → `render` + `keys`).
+Applying this update closes T103 in `tasks.md` (Polish phase).
 
 ## Project Structure
 

--- a/specs/001-popup-reader/quickstart.md
+++ b/specs/001-popup-reader/quickstart.md
@@ -1,0 +1,278 @@
+<!--
+SPDX-FileCopyrightText: 2026 Adam Poulemanos
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+# Quickstart: Popup Reader Validation
+
+**Spec**: 001-popup-reader
+**Audience**: implementer / reviewer verifying the feature end-to-end.
+
+This walk-through executes every functional requirement at least once. Run it
+against the `001-popup-reader` branch after `/speckit-implement` finishes.
+Each step lists which `FR-` / `SC-` / acceptance scenario it covers.
+
+## 0. Prerequisites
+
+- Go 1.26.2 (matches `go.mod`).
+- A modern terminal (xterm-compatible, ≥ 80×24).
+- For graphics tests (steps 6–7): Kitty, iTerm2, or WezTerm (or a terminal
+  with sixel support such as `foot`).
+- A scratch directory with sample assets:
+
+```bash
+mkdir -p /tmp/spy-fixtures
+echo 'package main\nfunc main(){println("hi")}' > /tmp/spy-fixtures/hello.go
+seq 1 10000 > /tmp/spy-fixtures/big.txt
+curl -sL https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf \
+  -o /tmp/spy-fixtures/dummy.pdf
+curl -sL https://www.w3.org/Graphics/PNG/iso_8859-1.png \
+  -o /tmp/spy-fixtures/iso.png
+```
+
+## 1. Build
+
+```bash
+go build -o bin/spy ./cmd/spy
+./bin/spy --version
+```
+
+Expected: `spy <version>` printed on stdout, exit 0.
+Covers: build sanity.
+
+## 2. Open a code file
+
+```bash
+./bin/spy /tmp/spy-fixtures/hello.go
+```
+
+Expected:
+- Alt-screen launches in under 100ms.
+- `hello.go` content visible with Go syntax highlighting.
+- Footer shows `hello.go | 3 lines | Line 1`.
+- `↓` / `j` (vim mode is off by default but vim keys still scroll, see below)
+  scrolls; `Esc` or `q` exits cleanly back to your prior shell prompt with no
+  visible artifacts.
+
+Covers: FR-001, FR-003, FR-008, FR-009, SC-001, SC-007, US1.
+
+## 3. Pipe input
+
+```bash
+git diff HEAD~ | ./bin/spy
+```
+
+Expected:
+- Alt-screen displays the diff with diff-style highlighting.
+- Footer reads `<stdin> | … lines | Line 1`.
+- No new files appear under `/tmp/`.
+- `Esc` exits and the shell shows your previous prompt unchanged.
+
+Covers: FR-002, US5, SC-011, no-disk-write assumption.
+
+## 4. Search and jump-to-line
+
+With `/tmp/spy-fixtures/big.txt` open:
+
+```bash
+./bin/spy /tmp/spy-fixtures/big.txt
+```
+
+In the viewer:
+
+1. Press `/`, type `9999`, press `Enter`. The viewport jumps to the line
+   containing `9999` and that match is highlighted.
+2. Press `n`. There are no further matches — status bar shows
+   `search wrapped` and the same match remains highlighted.
+3. Press `Esc` to clear search.
+4. Press `:`, type `1`, press `Enter`. The viewport jumps to line 1.
+5. Press `:`, type `$`, press `Enter`. The viewport jumps to the last line
+   and the footer shows the END indicator.
+
+Covers: FR-006, FR-007, US1 acceptance #4, US2 acceptance #2/#3/#4, SC-003.
+
+## 5. Vim mode
+
+```bash
+./bin/spy --vim /tmp/spy-fixtures/big.txt
+```
+
+In the viewer:
+
+- `j` / `k` scroll one line; `Ctrl-D` / `Ctrl-U` half-page; `gg` to top, `G`
+  to bottom.
+- `/`, `n`, `N` work as in step 4.
+
+Covers: FR-005 (default vs vim), Q3 clarification.
+
+Then verify default mode preserves arrow keys:
+
+```bash
+./bin/spy /tmp/spy-fixtures/big.txt
+```
+
+`↑` / `↓` / `PgUp` / `PgDn` / `Home` / `End` should all work.
+
+## 6. Theme detection and override
+
+Run on a light terminal:
+
+```bash
+./bin/spy /tmp/spy-fixtures/hello.go
+```
+
+Expected: highlighting uses the light theme; the footer/status bar is
+readable.
+
+Run with override:
+
+```bash
+./bin/spy --theme dark /tmp/spy-fixtures/hello.go
+```
+
+Expected: dark theme used regardless of terminal background. Setting
+`SPY_THEME=light` and re-running with no flag picks up the env override.
+
+Covers: FR-004, US3 acceptance #1/#2/#3, SC-004.
+
+## 7. Image rendering
+
+In a Kitty / iTerm2 / WezTerm window:
+
+```bash
+./bin/spy /tmp/spy-fixtures/iso.png
+```
+
+Expected: the PNG renders inline. `Esc` exits.
+
+In a non-graphics terminal (e.g., GNOME terminal):
+
+```bash
+./bin/spy /tmp/spy-fixtures/iso.png
+```
+
+Expected: a metadata block ("file name, dimensions, size, fallback message")
+displays. No corrupt characters or escape garbage.
+
+Covers: FR-010, US4 acceptance #2/#3, SC-009.
+
+## 8. PDF preview
+
+In a graphics-capable terminal:
+
+```bash
+./bin/spy /tmp/spy-fixtures/dummy.pdf
+```
+
+Expected:
+- First page rasterizes inline.
+- `]` advances to next page; `[` goes back.
+- Footer shows `dummy.pdf | Page 1/N`.
+
+In a non-graphics terminal:
+
+Expected: text extraction of page 1 displays with footer indicator;
+fallback message visible if the page is graphics-only.
+
+Covers: FR-011, US4 acceptance #1, SC-010.
+
+## 9. Large file handling
+
+```bash
+yes "the quick brown fox" | head -c 200M > /tmp/spy-fixtures/large.txt
+./bin/spy /tmp/spy-fixtures/large.txt
+```
+
+Expected:
+- Initial viewport paints in under 100ms.
+- Scrolling near the start is smooth.
+- Status bar shows `streaming…` indicator briefly when scrolling far ahead,
+  then clears.
+- Resident memory (check `RES` in `top` / `htop`) stays under 500 MB.
+
+Covers: FR-012, Q1 clarification, SC-005.
+
+## 10. Error path: file not found
+
+```bash
+./bin/spy /tmp/does-not-exist.txt; echo "exit=$?"
+```
+
+Expected:
+- Single line on stderr: `spy: cannot open: /tmp/does-not-exist.txt: no such file or directory`.
+- No alt-screen launched (terminal state unchanged).
+- Exit code `3`.
+
+Covers: FR-013, Q2 clarification.
+
+## 11. Error path: binary file
+
+```bash
+./bin/spy ./bin/spy; echo "exit=$?"
+```
+
+Expected: stderr `spy: binary file: ./bin/spy: refusing to render binary content`,
+exit code `4`, no alt-screen.
+
+Covers: FR-013, binary-file assumption.
+
+## 12. Resize handling
+
+Open a long file (`big.txt`), then resize the terminal window. Viewport
+should reflow without losing scroll position; line numbers should remain
+aligned; status bar should update its width.
+
+Covers: FR-014, SC-008, US1 edge case.
+
+## 13. Signal handling
+
+While the viewer is open, press `Ctrl-C`. The terminal should return
+cleanly: cursor visible, normal screen restored, prompt redrawn.
+
+Run again, send SIGTERM from another shell:
+
+```bash
+pkill -TERM spy
+```
+
+Same expected outcome.
+
+Covers: FR-015.
+
+## 14. Minimum-size degradation
+
+Resize the terminal to 60×20 (below the documented minimum) before
+launching. Open a code file. Expected:
+
+- No crash.
+- Footer collapses to a single short line; help bar hidden.
+- Body still readable; horizontal scroll works.
+
+Covers: Q4 clarification, "graceful degradation" assumption.
+
+## 15. Configuration file override
+
+```bash
+mkdir -p ~/.config/spy
+cat > ~/.config/spy/config.toml <<'TOML'
+theme    = "dark"
+vim_mode = true
+TOML
+./bin/spy /tmp/spy-fixtures/hello.go
+```
+
+Expected: launches with vim bindings active and dark theme regardless of
+terminal background. Remove the file when done.
+
+Covers: configuration assumption, contracts/config.md.
+
+---
+
+## Done criteria
+
+- [ ] All 15 steps pass on the implementer's machine.
+- [ ] Steps 7 and 8 pass on at least one Kitty / iTerm2 / WezTerm install
+      *and* at least one non-graphics terminal.
+- [ ] No leftover files under `/tmp/spy-fixtures/` retained in the
+      repository (these are scratch only).

--- a/specs/001-popup-reader/quickstart.md
+++ b/specs/001-popup-reader/quickstart.md
@@ -251,6 +251,25 @@ launching. Open a code file. Expected:
 
 Covers: Q4 clarification, "graceful degradation" assumption.
 
+## 14b. Empty input + file/stdin precedence
+
+```bash
+: > /tmp/spy-fixtures/empty.txt
+./bin/spy /tmp/spy-fixtures/empty.txt
+```
+
+Expected: viewer launches; body shows `(empty)`; footer
+`empty.txt | 0 lines | Line 0`; `q` dismisses with exit 0.
+
+```bash
+echo "this should be ignored" | ./bin/spy /tmp/spy-fixtures/hello.go
+```
+
+Expected: viewer shows `hello.go` content (NOT the piped text). The piped
+input is silently dropped.
+
+Covers: `contracts/cli.md` resolution table, empty-input edge case.
+
 ## 15. Configuration file override
 
 ```bash

--- a/specs/001-popup-reader/research.md
+++ b/specs/001-popup-reader/research.md
@@ -1,0 +1,396 @@
+<!--
+SPDX-FileCopyrightText: 2026 Adam Poulemanos
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+# Phase 0 Research: Popup Reader
+
+**Feature**: 001-popup-reader
+**Date**: 2026-04-25
+**Inputs**: [spec.md](./spec.md), existing skeleton in `cmd/spy` and `internal/*`
+
+This document resolves every NEEDS-CLARIFICATION-class unknown surfaced by the
+Technical Context in [plan.md](./plan.md). Each section follows the
+Decision / Rationale / Alternatives format.
+
+---
+
+## R1. Terminal capability detection
+
+**Decision**: Use a layered detection strategy:
+
+1. Honor explicit user override flags / env (`SPY_THEME`, `SPY_GRAPHICS=none|kitty|iterm2|sixel|auto`).
+2. Detect interactive TTY via `golang.org/x/term.IsTerminal(int(os.Stdout.Fd()))`. If false, fall back to plain stdout (no alt-screen, no graphics).
+3. For graphics protocols, probe in this order, accepting the first that succeeds:
+   - **Kitty graphics**: `TERM=xterm-kitty` or `KITTY_WINDOW_ID` set, *or* successful query of `\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\` with response within 100ms.
+   - **iTerm2 inline images**: `TERM_PROGRAM=iTerm.app` or `LC_TERMINAL=iTerm2`.
+   - **WezTerm**: `TERM_PROGRAM=WezTerm`. WezTerm advertises both Kitty and iTerm2 protocols; prefer Kitty.
+   - **Sixel**: send DA1 query `\x1b[c` and check response for `;4;` (sixel attribute) within 100ms.
+4. Color depth: trust `COLORTERM=truecolor|24bit` for true color; `TERM` containing `256color` for 256; otherwise 8-color.
+5. Dimensions: `term.GetSize(int(os.Stdout.Fd()))`; refresh on `tea.WindowSizeMsg`.
+
+**Rationale**: Pure env-var probing is fast and avoids race conditions, but Kitty
+under tmux/screen passthrough does not always set `KITTY_WINDOW_ID`; an active
+device-attribute probe with a tight timeout is the documented contract. iTerm2
+exports its own marker since 2018 and WezTerm explicitly mimics both. Falling
+back to `TERM_PROGRAM` keeps detection deterministic on common shells.
+
+**Alternatives considered**:
+- *Always probe by query*: rejected — adds 100–300ms to startup on every launch
+  and breaks `SC-001` (open under 100ms for a 100-line file).
+- *Use `github.com/gdamore/tcell` capability map*: rejected — Bubble Tea owns
+  the IO loop, mixing tcell would require rewriting the existing TUI shell.
+- *Trust `TERM` alone*: rejected — `TERM=xterm-256color` is the universal lie.
+
+---
+
+## R2. Image rendering
+
+**Decision**: Encode raw image bytes through three concrete renderers, selected
+at runtime by R1's capability detection:
+
+| Capability | Encoder | Library |
+|------------|---------|---------|
+| Kitty graphics | base64 + `\x1b_Ga=T,f=100;…\x1b\\` chunked at 4096B | hand-rolled (~80 LOC, see `internal/graphics/kitty.go`) |
+| iTerm2 inline | `\x1b]1337;File=inline=1;preserveAspectRatio=1:<base64>\x07` | hand-rolled |
+| Sixel | `golang.org/x/image` decode → `github.com/mattn/go-sixel` encode | external |
+| Fallback | size + dimensions metadata block (current behavior) | n/a |
+
+Source bytes come straight from disk for PNG/JPEG/GIF; for `image/*` types we
+already pull dimensions via `image.DecodeConfig`, so we re-open the file when
+rendering rather than caching the decoded `image.Image` in memory (large GIFs
+otherwise blow the SC-005 500MB ceiling).
+
+**Rationale**: Kitty and iTerm2 protocols are well-specified and each amount to
+a few dozen lines of code; pulling in heavyweight wrappers (e.g., `chafa`) just
+to re-implement the same thing buys nothing. `go-sixel` is the only mature
+pure-Go sixel encoder. Falling back to a metadata block matches FR-013 (graceful
+fallback) without misleading the user.
+
+**Alternatives considered**:
+- *`github.com/eliukblau/pixterm`*: rejected — emits ANSI half-block "image",
+  which is genuinely worse than honest metadata in unsupported terminals and
+  worse than native graphics in supported ones.
+- *Shell out to `chafa` / `viu`*: rejected — adds an unmanaged binary
+  dependency and breaks SC-005 piping semantics.
+- *Embed `libvips` via cgo*: rejected — cgo dependency, complicates static
+  builds, and we don't need transforms beyond "send what's on disk."
+
+---
+
+## R3. PDF preview
+
+**Decision**: PDF support has two tiers:
+
+1. **Default (always available)**: Use `pdfcpu` to extract page count, title,
+   author, and the first page's text, displayed as plain text with the rest of
+   the document accessible via page navigation (`]`/`[` or `:N`).
+2. **Graphics-capable terminals**: Rasterize the current page to PNG using
+   `github.com/gen2brain/go-fitz` (Go bindings for MuPDF) and feed the PNG
+   through R2. MuPDF is already a transitive dep of `pdfcpu` for some
+   operations but go-fitz vendors its own copy via cgo.
+
+The renderer falls back to text mode automatically if go-fitz is not available
+at build time (build tag `nofitz` for static / no-cgo builds). This satisfies
+FR-011 ("graceful fallback") in two dimensions: terminal capability *and*
+build configuration.
+
+**Rationale**: `pdfcpu` is already in `go.mod` and pure-Go, so the text path is
+free. MuPDF is the de-facto standard for high-fidelity PDF rasterization;
+alternatives (poppler, mupdf-tools as subprocess) are heavier and not faster.
+A build tag lets distributors ship a static binary without sacrificing the
+common case.
+
+**Alternatives considered**:
+- *Pure-Go rasterization via `unipdf`*: rejected — AGPL-licensed; incompatible
+  with project's MIT/Apache-2.0 dual license.
+- *Always shell out to `pdftoppm`*: rejected — same dependency-management
+  argument as R2's chafa rejection.
+- *No graphics for PDF*: rejected — FR-011 explicitly requires preview/render
+  in capable terminals.
+
+---
+
+## R4. Progressive loading with concurrency
+
+**Decision**: Implement progressive loading with a `loader.Stream` goroutine
+producing `tea.Msg` chunks, owned by a `bufio.Scanner` reading 64KiB at a time:
+
+```text
+loader.Open(source) → returns (firstChunk, streamCh, errCh)
+firstChunk = enough lines to fill the initial viewport (≥ height*2)
+streamCh   = subsequent chunks, posted as tea.Msg via tea.Cmd wrapper
+```
+
+The Bubble Tea model receives `chunkLoadedMsg{lines []Line, eof bool}` and
+appends to its in-memory buffer (`[]Line` slice of pre-tokenized rows). A
+`stopCh` is closed on quit/file-change to cancel the goroutine. Search and
+jump-to-line operate against the in-memory buffer; if the user scrolls past
+the loaded region we display a "loading…" indicator on the affected lines
+until the goroutine catches up.
+
+For files exceeding `MaxResidentBytes` (default 256MiB to stay under SC-005's
+500MB working-set ceiling), the loader switches to a windowed mode: it keeps
+the current viewport ± 4096 lines hot and discards the rest, re-reading from
+the file (which it keeps `os.Open`-ed for the lifetime of the session).
+
+**Rationale**: Goroutines + channels match the user's explicit Q1 answer
+("goroutines exist for a reason"). Posting through `tea.Cmd` keeps the model
+update path single-threaded — Bubble Tea's standard idiom. The chunked
+approach lets us hit SC-001 (≤100ms for 100 lines) trivially while still
+supporting SC-005 (1GB files under 500MB RAM) via the windowing mode.
+
+**Alternatives considered**:
+- *Read entire file synchronously*: rejected by Q1.
+- *Memory-map the file with `golang.org/x/exp/mmap`*: rejected — works for
+  on-disk files but not for stdin (FR-002), so we'd need two code paths;
+  the chunked reader handles both uniformly.
+- *Per-line goroutines*: rejected — channel overhead dominates.
+
+---
+
+## R5. Stdin / pipe handling
+
+**Decision**:
+
+1. At startup, check `term.IsTerminal(int(os.Stdin.Fd()))`. If false and no
+   file argument was passed, treat stdin as the source.
+2. Read stdin into the same `loader.Stream` pipeline; the underlying source
+   is just an `io.Reader`, so the chunked loader works without modification.
+3. Stdin content is held only in the in-memory ring buffer + sliding window;
+   we never write a temp file. (FR-002, plus assumption "no disk writes for
+   piped content".)
+4. If stdin is a TTY *and* no file argument is given, print usage to stderr
+   and exit non-zero — there's nothing to display.
+5. Language inference for piped content: try the shebang on the first line,
+   then the optional `--lang` / `-l` flag, then content sniffing via Chroma's
+   `lexers.Analyse`. If all three fail, render as plain text.
+
+**Rationale**: This mirrors how `bat` handles stdin (the user's stated
+reference). Keeping stdin entirely in memory is acceptable because stdin
+streams are bounded by `MaxResidentBytes` like any other source; a 2GB
+`cat huge.bin | spy` will hit the windowed-mode threshold and switch to
+"can't seek backwards in stdin" behavior — see R8.
+
+**Alternatives considered**:
+- *Buffer stdin to a temp file*: rejected by FR-002 / spec assumption.
+- *Default to JSON when stdin is structured*: rejected — out of scope for v1.
+
+---
+
+## R6. Theme detection (auto / dark / light)
+
+**Decision**: Detect terminal background once at startup using OSC 11:
+`\x1b]11;?\x07`. The terminal responds with `\x1b]11;rgb:RRRR/GGGG/BBBB\x07`
+within ~50ms in supporting terminals. Compute relative luminance; if < 0.5
+treat as dark, else light.
+
+If the query times out or the response is malformed, fall back to
+`COLORFGBG` env var (set by rxvt-style terminals). If that is also missing,
+default to **dark** — empirically the most common terminal default.
+
+The user can always override with `--theme dark|light` or
+`SPY_THEME=dark|light`. Theme switching at runtime (FR-004 acceptance #3)
+is implemented by sending a new theme into the renderer and re-rendering;
+the in-memory token buffer does not need to be re-tokenized — Chroma styles
+are applied at render time.
+
+**Rationale**: OSC 11 is the standard query, supported by xterm, kitty,
+iTerm2, WezTerm, alacritty, foot, and most modern emulators. Fall-back to
+env vars handles the long tail. The 50ms budget keeps us within SC-001.
+
+**Alternatives considered**:
+- *Always require explicit theme*: rejected — fails the user-facing promise
+  of "adapts automatically" in spec acceptance #1/2.
+- *Use `github.com/muesli/termenv`'s `HasDarkBackground`*: ✅ this is
+  acceptable and is already a transitive dependency via lipgloss; we will
+  use it as the *implementation* of the OSC 11 query and fall-back logic
+  rather than re-rolling. Decision stands; library is the means.
+
+---
+
+## R7. Streaming syntax highlighting with Chroma
+
+**Decision**: Tokenize lazily, render eagerly:
+
+1. The loader produces raw `[]Line` (string per line, no styling).
+2. A `highlighter` worker consumes lines from a channel, runs the configured
+   Chroma lexer in **streaming** mode (`chroma.Coalesce(lexer.TokeniseStreaming(...))`),
+   and emits `[]Token` per line.
+3. The render path joins tokens into ANSI-styled strings using a
+   `formatters.TTY256` or `formatters.TrueColour` formatter selected per R1.
+
+For files larger than `HighlightCap` (default 5MiB), highlighting is disabled
+and we render plain text — the cost-benefit of syntax-highlighting a 50MB log
+file is poor and risks SC-002 (smooth scroll on 10k-line files).
+
+**Rationale**: Chroma supports streaming via the iterator interface, but most
+of its lexers are stateful per-line; running per line is safe for the vast
+majority and an explicit cap protects worst cases. Pre-rendering ANSI strings
+once and caching them avoids re-tokenization on scroll (which hits SC-002).
+
+**Alternatives considered**:
+- *`github.com/sourcegraph/syntect-server` over HTTP*: rejected — external
+  service, adds latency, complicates packaging.
+- *`tree-sitter` via cgo*: rejected — heavier dep tree, marginal quality
+  improvement for terminal use, breaks pure-Go static builds.
+
+---
+
+## R8. Search and jump-to-line
+
+**Decision**:
+
+- **Search prompt**: `/` opens forward, `?` opens backward; both build on the
+  same `SearchState` (query, direction, matches []Position, currentMatch int).
+- **Match collection**: linear scan over the in-memory line buffer. For files
+  in windowed mode, search only the resident window initially; emit a
+  notification line "searching beyond loaded region…" while a background
+  goroutine completes the scan.
+- **Match navigation**: `n` next, `N` previous, wrap-around with a status-bar
+  hint ("search wrapped").
+- **Case sensitivity**: smart-case (case-insensitive when the query is
+  all-lowercase, case-sensitive otherwise). Toggleable via `\c` / `\C`
+  inside the prompt, mimicking vim/less.
+- **Regex**: opt-in via `--regex` flag or `\v` prefix in the prompt; default
+  is literal substring (faster, no surprise on `(` / `*` etc.).
+
+- **Jump-to-line**: `:N<enter>` or `gg` / `G` (vim mode only). `:0` or `:$`
+  resolves to the appropriate edge. Out-of-range jumps clamp to the last
+  loaded line and emit a status-bar warning rather than failing.
+
+**Rationale**: This is the same UX shipped by `less`, `bat --pager`, and
+`nvim`; users have built muscle memory for it. Smart-case is the most
+common compromise between strict and case-insensitive search.
+
+**Alternatives considered**:
+- *Fuzzy search (fzf-style)*: rejected — out of scope, adds significant
+  ranking infrastructure, deferred to v2.
+- *Always regex*: rejected — too many surprise-failures on plain text.
+
+---
+
+## R9. Viewport implementation
+
+**Decision**: Use `github.com/charmbracelet/bubbles/viewport` for the
+scrollable region. The current skeleton rolls its own viewport in
+`internal/ui/model.go`; replacing it with the upstream component buys us:
+
+- Smooth half-page / page scrolling, mouse wheel support.
+- High-water-mark tracking we'd otherwise re-implement.
+- Established support for resize (FR-014) and content replacement.
+
+The image / PDF page view is a separate `tea.Model` swapped into the same
+slot; the viewport is bypassed when graphics are emitted, since terminal
+graphics protocols don't compose with cell-based scrolling.
+
+**Rationale**: Reduces our maintenance surface; `bubbles/viewport` is the
+canonical Bubble Tea component for exactly this use case.
+
+**Alternatives considered**:
+- *Custom viewport (current code)*: keeps total deps smaller but duplicates
+  battle-tested code; rejected.
+
+---
+
+## R10. Signal handling and terminal restoration
+
+**Decision**: Bubble Tea's `tea.Program.Run()` already installs SIGINT / SIGTERM
+handlers, restores the terminal on panic, and exits the alt-screen on `tea.Quit`.
+Two additional measures are needed:
+
+1. Wrap `Run()` in a `defer` that calls `term.Restore(int(os.Stdout.Fd()), oldState)`
+   captured at startup. Belt-and-suspenders for the case where the program
+   crashes inside a third-party renderer (cgo fitz panic, etc.).
+2. Send Kitty graphics "delete all images" sequence (`\x1b_Ga=d,d=A;\x1b\\`)
+   on shutdown if any images were rendered, otherwise the terminal can leave
+   ghost images behind under tmux. iTerm2 cleans up automatically.
+
+**Rationale**: FR-015 demands clean exit on signals; the stock Bubble Tea
+behavior covers 95% of cases, and the explicit graphics-cleanup is a known
+gotcha not handled by the framework.
+
+**Alternatives considered**:
+- *Implement our own signal loop*: rejected — fights Bubble Tea's runtime.
+
+---
+
+## R11. Configuration loading
+
+**Decision**:
+
+- Config sources, in precedence (high → low):
+  1. CLI flags (`--theme`, `--vim`, `--regex`, `--no-color`, `--lang`, etc.)
+  2. Env vars (`SPY_THEME`, `SPY_VIM`, `SPY_GRAPHICS`, `NO_COLOR`)
+  3. Per-user config: `$XDG_CONFIG_HOME/spy/config.toml` (default
+     `$HOME/.config/spy/config.toml`)
+  4. Compiled defaults
+- Format: TOML via `github.com/BurntSushi/toml` (small, no transitive deps,
+  permissively licensed). Sample shipped at `examples/config.toml`.
+- The loader is best-effort: missing config file is not an error;
+  malformed config emits a single warning to stderr and uses defaults.
+
+**Rationale**: TOML matches the existing `_typos.toml`/`REUSE.toml` style
+already in the repo; XDG layering is the Linux norm and works on macOS.
+Honoring `NO_COLOR` is required by the de-facto convention
+(<https://no-color.org>).
+
+**Alternatives considered**:
+- *YAML*: rejected — heavier, ambiguous indentation surprises users.
+- *JSON*: rejected — comments forbidden, painful to edit by hand.
+- *No config file*: rejected — FR-004 acceptance #3 requires persistent
+  override across launches.
+
+---
+
+## R12. Keybinding model (default vs vim)
+
+**Decision**: A `KeyMap` struct with named bindings; two presets:
+
+- **Default (arrow keys primary)**: ↑/↓/←/→, PgUp/PgDn, Home/End, `q`/Esc
+  to quit, `/` to search, `:` for command (jump-to-line), `n`/`N` for next/prev
+  match, `?` for help.
+- **Vim (`--vim` or `vim_mode = true`)**: adds `h`/`j`/`k`/`l`, `gg`/`G`,
+  `Ctrl-D`/`Ctrl-U`, `Ctrl-F`/`Ctrl-B`, `0`/`$`. Arrow keys remain functional;
+  vim mode is additive, not exclusive.
+
+Bindings are defined via `bubbles/key`'s `key.Binding` so help text is
+auto-generated.
+
+**Rationale**: Matches the explicit Q3 answer ("arrow keys with optional vim
+mode"). Additive vim mode means power users get their bindings without
+penalising keyboard-shy users.
+
+**Alternatives considered**:
+- *Mode-exclusive*: rejected — punishes users who mix idioms.
+
+---
+
+## R13. Constitutional template (project-level)
+
+**Observation**: `.specify/memory/constitution.md` contains placeholder
+template content (`[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`, etc.) and has not
+been ratified for this project. The `/speckit-constitution` workflow has not
+been run.
+
+**Decision for this plan**: Proceed with a Constitution Check stub that
+declares "no ratified constitution; using sensible Go defaults aligned with
+[~/.claude/rules/golang/](~/.claude/rules/golang/) and the project's
+existing `DEVELOPMENT.md`". Recommend the user run `/speckit-constitution`
+before later features so future plans have real gates to evaluate against.
+
+**Rationale**: Blocking on an empty template would prevent any feature
+planning; we explicitly call out the gap so it's not silently hidden.
+
+---
+
+## Open issues deferred to /speckit-tasks or implementation
+
+- **PDF text extraction quality**: pdfcpu's text extraction is layout-naive.
+  If the rendered text proves unreadable for typical PDFs, consider switching
+  the default text extractor to go-fitz's `Page.Text()`.
+- **Mouse support**: scroll wheel comes for free with bubbles/viewport;
+  click-to-position is deferred to v2.
+- **Telemetry / observability**: deferred per Q4 clarification — no logging
+  unless `--debug` adds it.

--- a/specs/001-popup-reader/research.md
+++ b/specs/001-popup-reader/research.md
@@ -199,6 +199,27 @@ If the query times out or the response is malformed, fall back to
 `COLORFGBG` env var (set by rxvt-style terminals). If that is also missing,
 default to **dark** — empirically the most common terminal default.
 
+**Defensive parsing requirements** (security: a hostile or buggy terminal
+could reply with bytes that the rest of the program then interprets as user
+input). Implementation MUST:
+
+1. Read at most 64 bytes of response, with a 50 ms total deadline (`SetReadDeadline`).
+2. Validate the response against the strict regex
+   `^\x1b\](?:11|10);rgb:[0-9a-fA-F]{1,4}/[0-9a-fA-F]{1,4}/[0-9a-fA-F]{1,4}(?:\x07|\x1b\\)$`.
+3. On any of: timeout, length excess, regex mismatch, partial read — discard
+   the response entirely, **do not** echo or buffer it for later, fall back
+   to `COLORFGBG`. The OSC probe runs *before* alt-screen entry and *before*
+   any keyboard input loop, so even discarded bytes have nowhere to leak.
+4. Bytes between `\x1b]` and the terminator that include further `\x1b`
+   bytes (a malformed reply) are treated as a parse failure; never
+   re-injected into stdout.
+5. The probe is bypassed entirely when stdout is not a TTY, when `NO_COLOR`
+   is set, or when `SPY_THEME` provides an explicit value.
+
+These rules are exercised by `internal/term/theme_test.go` (T060) which
+includes adversarial reply fixtures (CSI-embedded, oversize, mid-stream
+abort).
+
 The user can always override with `--theme dark|light` or
 `SPY_THEME=dark|light`. Theme switching at runtime (FR-004 acceptance #3)
 is implemented by sending a new theme into the renderer and re-rendering;
@@ -232,7 +253,13 @@ env vars handles the long tail. The 50ms budget keeps us within SC-001.
 
 For files larger than `HighlightCap` (default 5MiB), highlighting is disabled
 and we render plain text — the cost-benefit of syntax-highlighting a 50MB log
-file is poor and risks SC-002 (smooth scroll on 10k-line files).
+file is poor and risks SC-002 (smooth scroll on 10k-line files). The downgrade
+is **surfaced**, not silent: the status bar shows
+`highlighting disabled (file > <cap>); set highlight_cap_bytes to override`
+on the first paint after detection. The message clears on the next non-error
+status update or after 5 s, whichever comes first. Users who want
+highlighting on large files raise `highlight_cap_bytes` in their config or
+pass `--highlight-cap=<bytes>` (added to `contracts/cli.md`).
 
 **Rationale**: Chroma supports streaming via the iterator interface, but most
 of its lexers are stateful per-line; running per line is safe for the vast

--- a/specs/001-popup-reader/research.md
+++ b/specs/001-popup-reader/research.md
@@ -298,21 +298,38 @@ canonical Bubble Tea component for exactly this use case.
 
 **Decision**: Bubble Tea's `tea.Program.Run()` already installs SIGINT / SIGTERM
 handlers, restores the terminal on panic, and exits the alt-screen on `tea.Quit`.
-Two additional measures are needed:
+Two additional measures are needed, and **both must run from the same `defer`
+chain in `main()` so they fire on panic, not just on graceful `tea.Quit`**:
 
-1. Wrap `Run()` in a `defer` that calls `term.Restore(int(os.Stdout.Fd()), oldState)`
-   captured at startup. Belt-and-suspenders for the case where the program
-   crashes inside a third-party renderer (cgo fitz panic, etc.).
-2. Send Kitty graphics "delete all images" sequence (`\x1b_Ga=d,d=A;\x1b\\`)
-   on shutdown if any images were rendered, otherwise the terminal can leave
-   ghost images behind under tmux. iTerm2 cleans up automatically.
+1. Capture terminal state at startup with `term.Restore()` (returns a closure).
+2. Capture a `cleanupGraphics func()` at startup that, when invoked, writes
+   the protocol-specific "delete all images" sequence to stdout — Kitty
+   (`\x1b_Ga=d,d=A;\x1b\\`) is the load-bearing case; iTerm2 and sixel
+   self-clean and the closure is a no-op for them; `GraphicsNone` is also a
+   no-op. The closure is idempotent.
+3. In `main()` after capability detection but before any rendering:
+   ```go
+   restore := term.Restore()
+   cleanupGraphics := graphics.CleanupFunc(caps.Graphics)
+   defer restore()           // outer: terminal modes/cursor/echo
+   defer cleanupGraphics()   // inner: graphics cleanup runs first (LIFO)
+   ```
+   Both fire on `tea.Quit`, on `os.Exit` from a signal, and — critically —
+   on panic, including a cgo `go-fitz` panic mid-render that bypasses Bubble
+   Tea's normal teardown. Re-emitting the cleanup escapes from `tea.Quit` is
+   redundant and harmless once these defers are in place.
 
 **Rationale**: FR-015 demands clean exit on signals; the stock Bubble Tea
-behavior covers 95% of cases, and the explicit graphics-cleanup is a known
-gotcha not handled by the framework.
+behavior covers `tea.Quit` and the SIGINT/SIGTERM happy path, but a panic
+inside a third-party renderer skips `tea.Quit` entirely. Routing graphics
+cleanup through `defer` (not through `tea.Cmd`) is the only way to guarantee
+it runs in every exit path. Ghost Kitty images persisting across sessions
+under tmux is a real, observable failure mode users will report as a bug.
 
 **Alternatives considered**:
 - *Implement our own signal loop*: rejected — fights Bubble Tea's runtime.
+- *Cleanup only on `tea.Quit`*: rejected — silently fails on panic; the very
+  case where users notice and complain.
 
 ---
 

--- a/specs/001-popup-reader/research.md
+++ b/specs/001-popup-reader/research.md
@@ -135,6 +135,15 @@ For files exceeding `MaxResidentBytes` (default 256MiB to stay under SC-005's
 the current viewport ± 4096 lines hot and discards the rest, re-reading from
 the file (which it keeps `os.Open`-ed for the lifetime of the session).
 
+**Backpressure**: `loader.Stream.Updates` is a *bounded* channel (capacity 4
+chunks). When the highlighter or the UI consumer falls behind, the loader
+goroutine blocks on send — preventing chunks (and the `Line.Raw` strings
+they hold) from accumulating in memory beyond ~4 × `InitialChunkLines` ×
+average-line-bytes (~256 KiB at defaults). The same applies to the
+intermediate channel between `loader` and `highlight.HighlightStream`:
+buffer 4. This is the single mechanism that keeps a fast on-disk source
+from breaching the 500 MB ceiling while the user idles in the viewer.
+
 **Rationale**: Goroutines + channels match the user's explicit Q1 answer
 ("goroutines exist for a reason"). Posting through `tea.Cmd` keeps the model
 update path single-threaded — Bubble Tea's standard idiom. The chunked

--- a/specs/001-popup-reader/spec.md
+++ b/specs/001-popup-reader/spec.md
@@ -17,10 +17,10 @@ A developer using tmux with multiple panes needs to quickly review a file withou
 
 **Acceptance Scenarios**:
 
-1. **Given** a file is open in a terminal pane, **When** user pipes file contents to spy, **Then** a focused popup window appears with syntax-highlighted content
-2. **Given** a popup viewer is open, **When** user scrolls through content, **Then** navigation is smooth and accessible via arrow keys or vim keybindings
-3. **Given** a popup viewer is open, **When** user presses escape or 'q', **Then** the popup closes and the terminal returns to previous state
-4. **Given** content fills multiple screens, **When** user navigates to end of file, **Then** the viewer indicates end-of-file status (e.g., "END" indicator)
+1. **Given** `hello.go` exists on disk, **When** user runs `spy hello.go`, **Then** the alt-screen launches within 100 ms (SC-001), `hello.go` content is visible with Go syntax highlighting applied via Chroma's `go` lexer, and the footer reads `hello.go | <N> lines | Line 1`.
+2. **Given** the viewer is open, **When** user presses `↓` or `j`, **Then** the viewport scrolls one line down without visible flicker; `PgDn` / `Space` advances one viewport-height; `Home` / `End` jump to top/bottom.
+3. **Given** the viewer is open, **When** user presses `q`, `Esc`, or `Ctrl-C`, **Then** the alt-screen exits, the previous shell prompt is visible unchanged (no residual escape sequences, cursor restored, modes restored), and the process exits with code 0 (or 130 for `Ctrl-C`) within the SC-007 budget.
+4. **Given** content fills multiple screens, **When** user scrolls past the last loaded line, **Then** the footer shows `END` styled with `Theme.Footer` and further down-scroll is a no-op (no error, no wrap).
 
 ---
 
@@ -34,10 +34,10 @@ A developer reviewing code in the popup needs proper syntax highlighting to quic
 
 **Acceptance Scenarios**:
 
-1. **Given** a code file is displayed, **When** the file type is detected, **Then** syntax highlighting is applied appropriately for that language
-2. **Given** content is displayed, **When** user presses ':' followed by a line number, **Then** the viewer jumps to that line and centers it on screen
-3. **Given** content is displayed, **When** user presses '/' or '?', **Then** a search prompt appears and can filter/highlight matching text
-4. **Given** multiple matches exist for a search, **When** user presses 'n' or 'N', **Then** the viewer navigates to next/previous match
+1. **Given** a file with a recognized extension or shebang is displayed, **When** the renderer initializes, **Then** Chroma selects a non-`fallback` lexer (verified per the SC-006 corpus) and tokens are styled per the active `Theme.ChromaStyle`.
+2. **Given** content is displayed, **When** user presses `:`, types `42`, presses `Enter`, **Then** the viewport jumps so line 42 is visible (centered if possible; clamped to last loaded line if 42 > total). Out-of-range jumps emit a status-bar warning (`line 99999 out of range; clamped to <last>`) rather than failing. `:0` aliases to line 1; `:$` aliases to the last line.
+3. **Given** content is displayed, **When** user presses `/`, types a query, presses `Enter`, **Then** the first match at-or-below the current line is highlighted with `Theme.SearchActive`; all other matches in the visible range are highlighted with `Theme.SearchHit`; the footer shows `<query> · <current>/<total>` matches. `?` performs the same with backward direction.
+4. **Given** N matches exist for the active search and the cursor is on match `i`, **When** user presses `n`, **Then** the viewport advances to match `i+1`; if `i == N`, it wraps to match 1 AND the status bar shows `search wrapped` until the next non-search keypress. `N` performs the reverse. With zero matches, the status bar shows `no matches for <query>` and `n`/`N` are no-ops.
 
 ---
 
@@ -51,9 +51,9 @@ A developer wants to use spy with their preferred terminal theme (dark or light 
 
 **Acceptance Scenarios**:
 
-1. **Given** spy is launched in a terminal with dark mode, **When** content is displayed, **Then** text colors are readable against the dark background
-2. **Given** spy is launched in a terminal with light mode, **When** content is displayed, **Then** text colors are readable against the light background
-3. **Given** spy is configured, **When** user sets theme preference via flag or config, **Then** the override is applied consistently across launches
+1. **Given** the terminal responds to OSC 11 with a background color whose relative luminance is ≥ 0.5 (light), **When** spy launches with `theme = "auto"` (default), **Then** `Theme.ChromaStyle` resolves to the `github` Chroma style and `Theme.LineNumber` / `Theme.Footer` use the light palette.
+2. **Given** the terminal background luminance is < 0.5 (dark) OR OSC 11 returns no response within 50 ms, **When** spy launches with `theme = "auto"`, **Then** `Theme.ChromaStyle` resolves to `monokai` and the dark palette is used.
+3. **Given** any terminal, **When** spy is invoked with `--theme dark|light|<chroma-style>` OR `SPY_THEME=…` is set OR `theme = "…"` is in the config file, **Then** the explicit value wins over auto-detection (precedence: flag > env > config > auto). Setting `--theme github` with no terminal probe still works.
 
 ---
 
@@ -85,9 +85,9 @@ A developer wants to pipe command output directly to spy without saving to a fil
 
 **Acceptance Scenarios**:
 
-1. **Given** text is piped to spy via stdin, **When** no file argument is provided, **Then** the content is displayed in the popup
-2. **Given** piped content is displayed, **When** syntax highlighting is applicable, **Then** highlighting is auto-detected or inferred from context
-3. **Given** piped content fills the screen, **When** the viewer closes, **Then** the piped content is not retained (no disk writes)
+1. **Given** stdin is non-TTY and no `FILE` argument is provided (e.g., `git diff | spy`), **When** spy starts, **Then** stdin content streams into the viewer; the footer shows `<stdin> | … lines | Line 1` (line count shows `…` until EOF, then the final count).
+2. **Given** piped content is displayed, **When** language detection runs, **Then** the order is: explicit `--lang` > shebang on first line (`#!/usr/bin/env python3` → `python`) > Chroma `lexers.Analyse` content sniffing > plain text fallback. Detection result appears in the footer when non-empty.
+3. **Given** piped content has been displayed and the viewer is dismissed, **When** the process exits, **Then** no file is created under `$TMPDIR`, `/tmp`, `$XDG_CACHE_HOME`, or the current working directory; verified by `tests/integration/stdin_test.go` snapshotting the relevant directories pre/post.
 
 ---
 

--- a/specs/001-popup-reader/spec.md
+++ b/specs/001-popup-reader/spec.md
@@ -59,17 +59,19 @@ A developer wants to use spy with their preferred terminal theme (dark or light 
 
 ### User Story 4 - PDF and Image Support in Modern Terminals (Priority: P2)
 
-A developer occasionally needs to review PDF documents or images (screenshots, diagrams) inline in their terminal workflow. Modern terminal emulators (iTerm2, Kitty, WezTerm) support inline image rendering, and spy should leverage this capability.
+**Primary actor**: developer triaging a bug report or reviewing a design artifact.
+**Trigger**: a teammate has shared a screenshot, diagram, or PDF (e.g., a Slack drop, a `gh issue view` attachment, a research paper from a download folder), and the developer wants to confirm the visual content matches the description without leaving the terminal or context-switching to a GUI viewer.
+**Goal**: see the image/PDF clearly enough to read embedded text and identify diagram structure (not just confirm a thumbnail is "the right colour"), or — when the terminal can't — get an honest, useful metadata fallback that names the file, dimensions, and size.
 
 **Why this priority**: This is a differentiator feature that extends spy beyond text-only viewers. While text is the primary use case, supporting PDFs and images in capable terminals adds significant value without disrupting the text workflow.
 
-**Independent Test**: Can be fully tested by opening a PDF in a capable terminal (Kitty or iTerm2), verifying at least basic display/thumbnail rendering, and confirming fallback behavior in terminals without image support.
+**Independent Test**: Can be fully tested by opening a PDF in a capable terminal (Kitty or iTerm2), verifying the rendered image is large enough to read 12-pt embedded text, and confirming the metadata fallback in terminals without image support shows filename + dimensions + size.
 
 **Acceptance Scenarios**:
 
-1. **Given** a PDF is piped to spy in a terminal that supports image rendering, **When** the file is identified as PDF, **Then** a preview/thumbnail is rendered if available
-2. **Given** an image file is piped to spy, **When** the terminal supports inline rendering (Kitty protocol), **Then** the image displays inline
-3. **Given** a terminal does not support image rendering, **When** a PDF or image is opened, **Then** a fallback message appears (e.g., "Image/PDF not supported in this terminal")
+1. **Given** a PDF is opened with `spy paper.pdf` in a Kitty/iTerm2/WezTerm session, **When** the file is identified as PDF, **Then** the current page rasterizes inline at the viewport width and rendered text in the page is readable at the user's normal terminal font size.
+2. **Given** an image file is opened with `spy diagram.png` in a Kitty/iTerm2/WezTerm session, **When** the terminal supports inline rendering, **Then** the image displays inline preserving aspect ratio and the user can identify text labels in the image.
+3. **Given** a terminal does not support image rendering (e.g., GNOME terminal), **When** a PDF or image is opened, **Then** a metadata block appears showing filename, dimensions (`W × H` for images, `N pages` for PDFs), file size, and a single-line note (`graphics not supported in this terminal`); for PDFs, page-1 text extraction is also displayed when available.
 
 ---
 
@@ -106,8 +108,11 @@ A developer using the tool wants to know which file they're viewing, how many li
 
 ### Edge Cases
 
-- How does the tool handle files with very long lines (>1000 characters)? (Wrap or horizontal scroll)
+- How does the tool handle files with very long lines (>1000 characters)? Soft-wrap by default (`word_wrap = true`); `--no-wrap` enables horizontal scroll. Lines longer than 100 KiB are truncated at 100 KiB with a status-bar warning to bound per-line memory.
 - What happens when terminal is resized while the viewer is open? (Already covered in FR-014)
+- What happens when both a file argument and non-TTY stdin are provided? File wins; stdin is ignored. See `contracts/cli.md` resolution table for the full matrix.
+- What happens with a 0-byte file or empty stdin? Viewer launches with a single styled `(empty)` line; not an error. See `contracts/cli.md` "Empty input".
+- What happens when a file is deleted or its permissions change while the viewer is open? Existing buffer remains viewable; reload (`Ctrl-R`/`r`) surfaces the failure as a status-bar error and keeps the prior buffer.
 
 ## Requirements *(mandatory)*
 
@@ -124,7 +129,7 @@ A developer using the tool wants to know which file they're viewing, how many li
 - **FR-009**: System MUST display file metadata in footer (file name, line count, current position) when viewing files
 - **FR-010**: System MUST support detection and inline rendering of image files in compatible terminals (Kitty, iTerm2, WezTerm)
 - **FR-011**: System MUST support PDF preview/rendering in compatible terminals with graceful fallback in unsupported terminals
-- **FR-012**: System MUST handle very large files gracefully via progressive loading (load initial viewport immediately, stream remaining content in background using concurrent goroutines)
+- **FR-012**: System MUST handle large files gracefully via progressive loading (initial viewport paints immediately while remaining content streams in the background). Files exceeding 256 MiB MUST switch to windowed mode (a sliding hot region kept in RAM, with the rest re-read from disk on demand). Files up to 1 GiB MUST remain viewable, with resident memory ≤ 500 MB (cross-ref SC-005). For non-seekable sources (stdin) above 256 MiB, the viewer enters scroll-forward-only mode with a status-bar warning rather than failing.
 - **FR-013**: System MUST output error messages to stderr (single-line, prefixed `spy: <reason>: <detail>`) and exit without launching the viewer if file is inaccessible, binary, or unsupported format. Exit codes follow `contracts/cli.md` (3 = I/O, 4 = unsupported, 2 = usage)
 - **FR-014**: System MUST handle terminal resize events and reflow content appropriately
 - **FR-015**: System MUST exit cleanly on signals (SIGINT, SIGTERM) without corrupting terminal state
@@ -182,13 +187,13 @@ A developer using the tool wants to know which file they're viewing, how many li
 - **SC-003**: Text search returns results in under 500ms even in files larger than 1MB
 - **SC-004**: Theme switching between dark/light modes occurs instantly without visual artifacts
 - **SC-005**: The tool successfully handles file sizes up to 1GB without consuming more than 500MB of memory
-- **SC-006**: 95% of common programming languages (Go, Python, JavaScript, Rust, Java, C, etc.) have correct syntax highlighting
-- **SC-007**: Users can dismiss the viewer and return to their terminal in under 500ms
+- **SC-006**: For a fixed corpus of 50 representative source files (one per language from the GitHub Linguist top-50 by repository count, captured under `tests/fixtures/highlight-corpus/`), Chroma successfully selects a non-`fallback` lexer and produces tokenization where ≤ 1 % of bytes per file land in `chroma.Error` tokens. Pass threshold: ≥ 47/50 files (94 %). Measured by `tests/perf/highlight_corpus_test.go`.
+- **SC-007**: From the user pressing `q`/`Esc`/`Ctrl-C` to `tea.Program.Run()` returning and the alt-screen having been exited (terminal back to main screen, cursor restored), elapsed wall-clock ≤ 500 ms at the 95th percentile across 100 invocations against `/tmp/spy-fixtures/big.txt` (10 000 lines). Measured by `tests/perf/dismiss_bench_test.go` driving the PTY harness.
 - **SC-008**: Terminal resize events are handled without visual corruption or loss of viewport state
 - **SC-009**: Image rendering in Kitty/iTerm2 terminals displays correctly for JPEG, PNG, and GIF files under 50MB
 - **SC-010**: PDF preview/rendering works in supported terminals; fallback message appears clearly in unsupported terminals
 - **SC-011**: Piped input from common commands (cat, git diff, grep, etc.) displays correctly
-- **SC-012**: 90% of users can complete a typical code review task (find specific line, search for text, navigate to end, dismiss) without consulting documentation
+- **SC-012**: Three independent reviewers (not the implementer) complete the `quickstart.md` Steps 2, 4, and 12 (open file, search + jump-to-line, resize) using only the in-app help overlay (`F1`/`?`); each reviewer records pass/fail and notes blockers in `specs/001-popup-reader/checklists/quickstart-validation.md`. Pass threshold: 3/3 reviewers pass all three steps without escaping to external docs. *Note*: original SC-012 ("90 % of users without docs") would require a funded user study with N ≥ 20; deferred to a post-v0.1.0 success metric. The reviewer-panel heuristic above is the v0.1.0 gate.
 
 ## Assumptions
 

--- a/specs/001-popup-reader/spec.md
+++ b/specs/001-popup-reader/spec.md
@@ -204,6 +204,6 @@ A developer using the tool wants to know which file they're viewing, how many li
 - **Binary File Behavior**: Binary files will display a clear "unsupported format" message rather than attempting to render binary data.
 - **Terminal State Preservation**: The tool will restore terminal state (colors, cursor position, echo mode) on exit in all cases, even on error or signal.
 - **Configuration**: User preferences (theme, keybindings) can be configured via a simple config file (~/.spy/config) or environment variables; full config system design is out of scope for v1.
-- **Stdin Handling**: Piped input is read entirely before display; streaming very large piped inputs may require pagination (design detail for planning phase).
+- **Stdin Handling**: Piped input streams into the viewer through the same chunked loader as files (per FR-002 and US5 acceptance #1); content is held only in memory subject to the FR-012 resident-memory bound, and is never persisted to disk. Non-seekable stdin above the windowed-mode threshold falls back to scroll-forward-only mode with a status-bar warning (per FR-012).
 - **Large File Loading**: Large files (>100MB) use progressive/concurrent loading: initial viewport displays immediately while remaining content streams in background. No blocking waits for full file load.
 - **Keyboard Shortcuts**: Default keybindings use arrow keys for navigation (accessible to all users). Optional vim mode (hjkl, /, :) can be enabled via `--vim` flag or config file. Emacs keybindings and full customization out of scope for v1.

--- a/specs/001-popup-reader/spec.md
+++ b/specs/001-popup-reader/spec.md
@@ -183,16 +183,16 @@ A developer using the tool wants to know which file they're viewing, how many li
 ### Measurable Outcomes
 
 - **SC-001**: Users can open and view a 100-line text file with syntax highlighting in under 100ms from invocation
-- **SC-002**: Navigation through a 10,000-line file is smooth with no perceivable lag when pressing arrow keys
+- **SC-002**: Scrolling a 10 000-line file (`/tmp/spy-fixtures/big.txt`) is smooth. Measured by `tests/perf/scroll_bench_test.go`: 100 sequential ScrollDown actions driven through the PTY harness, p95 per-frame wall-clock ≤ 16 ms (60 fps target) and zero dropped frames.
 - **SC-003**: Text search returns results in under 500ms even in files larger than 1MB
-- **SC-004**: Theme switching between dark/light modes occurs instantly without visual artifacts
+- **SC-004**: Theme switching at runtime (`:set theme dark|light|<style>`) re-renders the visible viewport in ≤ 16 ms p95 without re-tokenizing the in-memory buffer (Chroma styles are applied at format time per research R7). Measured by `tests/perf/theme_swap_bench_test.go` averaging 100 swaps against a 10 000-line file.
 - **SC-005**: The tool successfully handles file sizes up to 1GB without consuming more than 500MB of memory
 - **SC-006**: For a fixed corpus of 50 representative source files (one per language from the GitHub Linguist top-50 by repository count, captured under `tests/fixtures/highlight-corpus/`), Chroma successfully selects a non-`fallback` lexer and produces tokenization where ≤ 1 % of bytes per file land in `chroma.Error` tokens. Pass threshold: ≥ 47/50 files (94 %). Measured by `tests/perf/highlight_corpus_test.go`.
 - **SC-007**: From the user pressing `q`/`Esc`/`Ctrl-C` to `tea.Program.Run()` returning and the alt-screen having been exited (terminal back to main screen, cursor restored), elapsed wall-clock ≤ 500 ms at the 95th percentile across 100 invocations against `/tmp/spy-fixtures/big.txt` (10 000 lines). Measured by `tests/perf/dismiss_bench_test.go` driving the PTY harness.
-- **SC-008**: Terminal resize events are handled without visual corruption or loss of viewport state
-- **SC-009**: Image rendering in Kitty/iTerm2 terminals displays correctly for JPEG, PNG, and GIF files under 50MB
-- **SC-010**: PDF preview/rendering works in supported terminals; fallback message appears clearly in unsupported terminals
-- **SC-011**: Piped input from common commands (cat, git diff, grep, etc.) displays correctly
+- **SC-008**: After a `tea.WindowSizeMsg` arrives, (a) the line previously at viewport row 0 remains at row 0, (b) the wrap cache is invalidated, (c) the next frame paints in ≤ 16 ms p95. Measured by `tests/integration/resize_test.go` driving 50 successive resize events at random widths in `[40, 200]` cols.
+- **SC-009**: For each fixture in `tests/fixtures/img/{small.png 32 KB, medium.jpg 5 MB, large.gif 49 MB}`, `spy <file>` in a Kitty-emulating PTY (a) emits a Kitty payload that round-trips through the harness's reference decoder back to a pixel-identical `image.Image`, (b) exits 0, (c) keeps resident memory ≤ 250 MB. Measured by `tests/integration/graphics_test.go` (extends T073).
+- **SC-010**: For `dummy.pdf` (single-page, known text "Dummy PDF file") and `tests/fixtures/pdf/multi-page.pdf` (3 pages), the renderer (a) rasterizes page 1 via `graphics.PDFPage` under `-tags fitz` in a graphics-capable PTY, and (b) extracts page text via `pdfcpu` in a non-graphics PTY — the extracted text MUST contain the known sentinel string. Measured by `tests/integration/pdf_test.go`.
+- **SC-011**: Three pipeline shapes pass end-to-end in `tests/e2e/05_pipe.sh`: (a) `cat tests/fixtures/hello.go | spy -l go` displays Go-highlighted content with `<stdin>` in the footer; (b) `git diff HEAD~ | spy` displays diff-highlighted content; (c) `grep -n needle tests/fixtures/hello.go | spy` displays plain text with `<stdin>` in the footer. All three exit 0 on `q`.
 - **SC-012**: Three independent reviewers (not the implementer) complete the `quickstart.md` Steps 2, 4, and 12 (open file, search + jump-to-line, resize) using only the in-app help overlay (`F1`/`?`); each reviewer records pass/fail and notes blockers in `specs/001-popup-reader/checklists/quickstart-validation.md`. Pass threshold: 3/3 reviewers pass all three steps without escaping to external docs. *Note*: original SC-012 ("90 % of users without docs") would require a funded user study with N ≥ 20; deferred to a post-v0.1.0 success metric. The reviewer-panel heuristic above is the v0.1.0 gate.
 
 ## Assumptions

--- a/specs/001-popup-reader/spec.md
+++ b/specs/001-popup-reader/spec.md
@@ -125,7 +125,7 @@ A developer using the tool wants to know which file they're viewing, how many li
 - **FR-010**: System MUST support detection and inline rendering of image files in compatible terminals (Kitty, iTerm2, WezTerm)
 - **FR-011**: System MUST support PDF preview/rendering in compatible terminals with graceful fallback in unsupported terminals
 - **FR-012**: System MUST handle very large files gracefully via progressive loading (load initial viewport immediately, stream remaining content in background using concurrent goroutines)
-- **FR-013**: System MUST output error messages to stdout and exit without launching the viewer if file is inaccessible, binary, or unsupported format
+- **FR-013**: System MUST output error messages to stderr (single-line, prefixed `spy: <reason>: <detail>`) and exit without launching the viewer if file is inaccessible, binary, or unsupported format. Exit codes follow `contracts/cli.md` (3 = I/O, 4 = unsupported, 2 = usage)
 - **FR-014**: System MUST handle terminal resize events and reflow content appropriately
 - **FR-015**: System MUST exit cleanly on signals (SIGINT, SIGTERM) without corrupting terminal state
 
@@ -157,10 +157,11 @@ A developer using the tool wants to know which file they're viewing, how many li
   - No blocking on initial display; user sees content immediately
   - Graceful scrolling within loaded region; degradation only if scrolling ahead of stream
 
-- **Q2: Error Handling & Fallback UX** → **A: Errors to stdout, no viewer display (minimal Unix approach)**
-  - If file cannot be accessed, is binary, or format unsupported: print error message to stdout and exit
+- **Q2: Error Handling & Fallback UX** → **A: Errors to stderr, no viewer display (minimal Unix approach)**
+  - If file cannot be accessed, is binary, or format unsupported: print error message to stderr (`spy: <reason>: <detail>`) and exit with the matching code from `contracts/cli.md`
   - Viewer only launches if there is displayable content
   - No error dialogs or fallback rendering; fail fast and cleanly
+  - *Note*: original Q2 wording said "stdout"; corrected here to match Unix convention and `contracts/cli.md`. Stdout is reserved for the alt-screen TUI (TTY) or verbatim content (degenerate-cat mode).
 
 - **Q3: Accessibility & Keybinding Scope** → **A: Arrow keys primary with optional vim mode (inverted approach)**
   - Default keybindings use arrow keys (↑↓←→) for maximum accessibility

--- a/specs/001-popup-reader/spec.md
+++ b/specs/001-popup-reader/spec.md
@@ -1,0 +1,203 @@
+# Feature Specification: Popup Reader - Focused Text/PDF/Image Viewer
+
+**Feature Branch**: `001-popup-reader`  
+**Created**: 2026-04-25  
+**Status**: Draft  
+**Input**: Design a focused review tool with popup window for viewing text in tmux panes with syntax highlighting, theming, and PDF/image support
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Quick Text Review in Terminal Panes (Priority: P1)
+
+A developer using tmux with multiple panes needs to quickly review a file without leaving the terminal environment or disrupting their current layout. They want to "pop up" a focused view that displays the file contents with proper syntax highlighting, then dismiss it to return to their normal workflow.
+
+**Why this priority**: This is the core use case - solving the problem of difficult text review in constrained terminal environments. It's the MVP that delivers immediate value.
+
+**Independent Test**: Can be fully tested by opening a text file with spy in a terminal, verifying syntax highlighting displays correctly, and confirming the window can be dismissed without losing terminal state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a file is open in a terminal pane, **When** user pipes file contents to spy, **Then** a focused popup window appears with syntax-highlighted content
+2. **Given** a popup viewer is open, **When** user scrolls through content, **Then** navigation is smooth and accessible via arrow keys or vim keybindings
+3. **Given** a popup viewer is open, **When** user presses escape or 'q', **Then** the popup closes and the terminal returns to previous state
+4. **Given** content fills multiple screens, **When** user navigates to end of file, **Then** the viewer indicates end-of-file status (e.g., "END" indicator)
+
+---
+
+### User Story 2 - Syntax Highlighting and Code Navigation (Priority: P1)
+
+A developer reviewing code in the popup needs proper syntax highlighting to quickly understand the code structure, and wants to navigate efficiently using common patterns (jump to line, search for text).
+
+**Why this priority**: Syntax highlighting is essential for code review and is a core differentiator from simple cat/less viewers. Code navigation enables real review workflows.
+
+**Independent Test**: Can be fully tested by opening a code file (e.g., Go, Python, JavaScript), verifying correct syntax coloring, testing line-number navigation, and confirming search functionality works.
+
+**Acceptance Scenarios**:
+
+1. **Given** a code file is displayed, **When** the file type is detected, **Then** syntax highlighting is applied appropriately for that language
+2. **Given** content is displayed, **When** user presses ':' followed by a line number, **Then** the viewer jumps to that line and centers it on screen
+3. **Given** content is displayed, **When** user presses '/' or '?', **Then** a search prompt appears and can filter/highlight matching text
+4. **Given** multiple matches exist for a search, **When** user presses 'n' or 'N', **Then** the viewer navigates to next/previous match
+
+---
+
+### User Story 3 - Dark/Light Theme Support (Priority: P1)
+
+A developer wants to use spy with their preferred terminal theme (dark or light mode) without jarring color mismatches. The viewer should adapt to the terminal's theme automatically or allow manual override.
+
+**Why this priority**: Terminal theming is fundamental to the user experience. Poor color contrast or theme mismatches would make the tool unusable in many environments.
+
+**Independent Test**: Can be fully tested by running spy with a light terminal theme, verifying readability, then switching to dark theme and confirming colors adapt appropriately.
+
+**Acceptance Scenarios**:
+
+1. **Given** spy is launched in a terminal with dark mode, **When** content is displayed, **Then** text colors are readable against the dark background
+2. **Given** spy is launched in a terminal with light mode, **When** content is displayed, **Then** text colors are readable against the light background
+3. **Given** spy is configured, **When** user sets theme preference via flag or config, **Then** the override is applied consistently across launches
+
+---
+
+### User Story 4 - PDF and Image Support in Modern Terminals (Priority: P2)
+
+A developer occasionally needs to review PDF documents or images (screenshots, diagrams) inline in their terminal workflow. Modern terminal emulators (iTerm2, Kitty, WezTerm) support inline image rendering, and spy should leverage this capability.
+
+**Why this priority**: This is a differentiator feature that extends spy beyond text-only viewers. While text is the primary use case, supporting PDFs and images in capable terminals adds significant value without disrupting the text workflow.
+
+**Independent Test**: Can be fully tested by opening a PDF in a capable terminal (Kitty or iTerm2), verifying at least basic display/thumbnail rendering, and confirming fallback behavior in terminals without image support.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PDF is piped to spy in a terminal that supports image rendering, **When** the file is identified as PDF, **Then** a preview/thumbnail is rendered if available
+2. **Given** an image file is piped to spy, **When** the terminal supports inline rendering (Kitty protocol), **Then** the image displays inline
+3. **Given** a terminal does not support image rendering, **When** a PDF or image is opened, **Then** a fallback message appears (e.g., "Image/PDF not supported in this terminal")
+
+---
+
+### User Story 5 - Pipe Input Support (Priority: P2)
+
+A developer wants to pipe command output directly to spy without saving to a file, similar to how bat handles piped input. This enables workflows like `cat file.go | spy` or `git diff HEAD~ | spy`.
+
+**Why this priority**: Piping is a Unix philosophy pattern that enables flexible workflows. It's important but secondary to opening files directly.
+
+**Independent Test**: Can be fully tested by running `echo "test content" | spy`, verifying content displays correctly, and testing with command output (e.g., `git diff | spy`).
+
+**Acceptance Scenarios**:
+
+1. **Given** text is piped to spy via stdin, **When** no file argument is provided, **Then** the content is displayed in the popup
+2. **Given** piped content is displayed, **When** syntax highlighting is applicable, **Then** highlighting is auto-detected or inferred from context
+3. **Given** piped content fills the screen, **When** the viewer closes, **Then** the piped content is not retained (no disk writes)
+
+---
+
+### User Story 6 - File Metadata and Navigation Context (Priority: P3)
+
+A developer using the tool wants to know which file they're viewing, how many lines it contains, and their current position in the file. This context helps during code review.
+
+**Why this priority**: Nice-to-have feature that improves usability but isn't essential for core functionality. Can enhance the experience after MVP is solid.
+
+**Independent Test**: Can be fully tested by opening a file and checking that the footer displays file name, line count, and current position (e.g., "file.go | 245 lines | Line 42").
+
+**Acceptance Scenarios**:
+
+1. **Given** a file is displayed, **When** the viewer is open, **Then** a footer shows the file name and total line count
+2. **Given** user navigates through content, **When** they are at line N of M, **Then** the footer updates to show current line position
+
+---
+
+### Edge Cases
+
+- How does the tool handle files with very long lines (>1000 characters)? (Wrap or horizontal scroll)
+- What happens when terminal is resized while the viewer is open? (Already covered in FR-014)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST accept file path as command-line argument: `spy <file>`
+- **FR-002**: System MUST accept piped input and display contents when invoked without file argument
+- **FR-003**: System MUST apply syntax highlighting based on file extension or inferred language type
+- **FR-004**: System MUST support dark mode and light mode themes that adapt to terminal capabilities
+- **FR-005**: System MUST provide keyboard navigation via arrow keys (↑↓←→, page up/down) as primary; optional vim mode (hjkl, /, :) enabled via flag or config
+- **FR-006**: System MUST support jumping to specific line numbers via ':' command followed by line number
+- **FR-007**: System MUST support text search via '/' (forward) and '?' (backward) with 'n'/'N' navigation
+- **FR-008**: System MUST allow dismissal of viewer via 'q' or 'ESC' key without altering terminal state
+- **FR-009**: System MUST display file metadata in footer (file name, line count, current position) when viewing files
+- **FR-010**: System MUST support detection and inline rendering of image files in compatible terminals (Kitty, iTerm2, WezTerm)
+- **FR-011**: System MUST support PDF preview/rendering in compatible terminals with graceful fallback in unsupported terminals
+- **FR-012**: System MUST handle very large files gracefully via progressive loading (load initial viewport immediately, stream remaining content in background using concurrent goroutines)
+- **FR-013**: System MUST output error messages to stdout and exit without launching the viewer if file is inaccessible, binary, or unsupported format
+- **FR-014**: System MUST handle terminal resize events and reflow content appropriately
+- **FR-015**: System MUST exit cleanly on signals (SIGINT, SIGTERM) without corrupting terminal state
+
+### Key Entities
+
+- **ViewerSession**: Represents an active spy viewing session
+  - Current file or piped content
+  - Current scroll position
+  - Search state (active search query, current match position)
+  - Theme preference (dark/light/auto)
+  
+- **FileMetadata**: Information about the file being viewed
+  - File path or source (stdin, file)
+  - File type/language for syntax highlighting
+  - Line count
+  - File size
+  
+- **TerminalCapabilities**: Terminal feature detection
+  - Supports image rendering (Kitty protocol, iTerm2, etc.)
+  - Color depth (8-bit, 256-color, true color)
+  - Dimensions (rows, columns)
+
+## Clarifications
+
+### Session 2026-04-25
+
+- **Q1: Loading & Streaming Strategy for Large Files** → **A: Progressive loading with concurrent goroutines (Option B)**
+  - Large files load viewport first, remaining content streams in background
+  - No blocking on initial display; user sees content immediately
+  - Graceful scrolling within loaded region; degradation only if scrolling ahead of stream
+
+- **Q2: Error Handling & Fallback UX** → **A: Errors to stdout, no viewer display (minimal Unix approach)**
+  - If file cannot be accessed, is binary, or format unsupported: print error message to stdout and exit
+  - Viewer only launches if there is displayable content
+  - No error dialogs or fallback rendering; fail fast and cleanly
+
+- **Q3: Accessibility & Keybinding Scope** → **A: Arrow keys primary with optional vim mode (inverted approach)**
+  - Default keybindings use arrow keys (↑↓←→) for maximum accessibility
+  - Vim mode (hjkl, /, :) available as optional flag or config for power users
+  - No Emacs keybindings or advanced remapping in v1
+
+- **Q4: Minimum Terminal Dimensions & Small Window Behavior** → **A: Graceful degradation with 80×24 minimum (Option B)**
+  - Minimum supported terminal size: 80 columns × 24 rows (standard terminal)
+  - Below 80 columns or 8 rows: tool still functions but with reduced layout (single-column view, minimal footer)
+  - No hard error; graceful behavior across all reasonable terminal sizes
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can open and view a 100-line text file with syntax highlighting in under 100ms from invocation
+- **SC-002**: Navigation through a 10,000-line file is smooth with no perceivable lag when pressing arrow keys
+- **SC-003**: Text search returns results in under 500ms even in files larger than 1MB
+- **SC-004**: Theme switching between dark/light modes occurs instantly without visual artifacts
+- **SC-005**: The tool successfully handles file sizes up to 1GB without consuming more than 500MB of memory
+- **SC-006**: 95% of common programming languages (Go, Python, JavaScript, Rust, Java, C, etc.) have correct syntax highlighting
+- **SC-007**: Users can dismiss the viewer and return to their terminal in under 500ms
+- **SC-008**: Terminal resize events are handled without visual corruption or loss of viewport state
+- **SC-009**: Image rendering in Kitty/iTerm2 terminals displays correctly for JPEG, PNG, and GIF files under 50MB
+- **SC-010**: PDF preview/rendering works in supported terminals; fallback message appears clearly in unsupported terminals
+- **SC-011**: Piped input from common commands (cat, git diff, grep, etc.) displays correctly
+- **SC-012**: 90% of users can complete a typical code review task (find specific line, search for text, navigate to end, dismiss) without consulting documentation
+
+## Assumptions
+
+- **User Environment**: Users have access to a modern terminal emulator (xterm-compatible or better) with at least 256 colors support. Minimum supported dimensions are 80×24 (standard terminal); tool degrades gracefully below 80 columns or 8 rows. Extended image support (Kitty protocol, iTerm2) is optional but enables enhanced features.
+- **File System**: Spy operates on local files only; remote file systems (NFS, SSH) are out of scope for v1 but could be added if performance is acceptable.
+- **Scope - Text Focus**: The primary use case is text file review; PDF and image support is supplementary and can degrade gracefully.
+- **Large File Handling**: Files larger than 1GB should be handled via streaming or pagination; attempting to load entire file into memory is prohibited.
+- **Binary File Behavior**: Binary files will display a clear "unsupported format" message rather than attempting to render binary data.
+- **Terminal State Preservation**: The tool will restore terminal state (colors, cursor position, echo mode) on exit in all cases, even on error or signal.
+- **Configuration**: User preferences (theme, keybindings) can be configured via a simple config file (~/.spy/config) or environment variables; full config system design is out of scope for v1.
+- **Stdin Handling**: Piped input is read entirely before display; streaming very large piped inputs may require pagination (design detail for planning phase).
+- **Large File Loading**: Large files (>100MB) use progressive/concurrent loading: initial viewport displays immediately while remaining content streams in background. No blocking waits for full file load.
+- **Keyboard Shortcuts**: Default keybindings use arrow keys for navigation (accessible to all users). Optional vim mode (hjkl, /, :) can be enabled via `--vim` flag or config file. Emacs keybindings and full customization out of scope for v1.

--- a/specs/001-popup-reader/spec.md
+++ b/specs/001-popup-reader/spec.md
@@ -69,8 +69,8 @@ A developer wants to use spy with their preferred terminal theme (dark or light 
 
 **Acceptance Scenarios**:
 
-1. **Given** a PDF is opened with `spy paper.pdf` in a Kitty/iTerm2/WezTerm session, **When** the file is identified as PDF, **Then** the current page rasterizes inline at the viewport width and rendered text in the page is readable at the user's normal terminal font size.
-2. **Given** an image file is opened with `spy diagram.png` in a Kitty/iTerm2/WezTerm session, **When** the terminal supports inline rendering, **Then** the image displays inline preserving aspect ratio and the user can identify text labels in the image.
+1. **Given** a PDF is opened with `spy paper.pdf` in a Kitty/iTerm2/WezTerm session, **When** the file is identified as PDF, **Then** the current page rasterizes inline filling ≥ 80 % of the available viewport width while preserving aspect ratio; rendered pixel dimensions are recorded in `checklists/quickstart-validation.md` for the human-eye legibility step (see SC-012 reviewer panel).
+2. **Given** an image file is opened with `spy diagram.png` in a Kitty/iTerm2/WezTerm session, **When** the terminal supports inline rendering, **Then** the image displays inline preserving aspect ratio, scaling to fill ≥ 80 % of the viewport width or the image's native dimensions (whichever is smaller); legibility of any embedded text labels is recorded per reviewer in `checklists/quickstart-validation.md`.
 3. **Given** a terminal does not support image rendering (e.g., GNOME terminal), **When** a PDF or image is opened, **Then** a metadata block appears showing filename, dimensions (`W × H` for images, `N pages` for PDFs), file size, and a single-line note (`graphics not supported in this terminal`); for PDFs, page-1 text extraction is also displayed when available.
 
 ---
@@ -109,7 +109,7 @@ A developer using the tool wants to know which file they're viewing, how many li
 ### Edge Cases
 
 - How does the tool handle files with very long lines (>1000 characters)? Soft-wrap by default (`word_wrap = true`); `--no-wrap` enables horizontal scroll. Lines longer than 100 KiB are truncated at 100 KiB with a status-bar warning to bound per-line memory.
-- What happens when terminal is resized while the viewer is open? (Already covered in FR-014)
+- What happens when the terminal is resized while a `/` or `:` prompt is open? The prompt re-positions to the new viewport bottom; the buffered query characters and history cursor are preserved; any in-progress background search re-targets the resized line buffer.
 - What happens when both a file argument and non-TTY stdin are provided? File wins; stdin is ignored. See `contracts/cli.md` resolution table for the full matrix.
 - What happens with a 0-byte file or empty stdin? Viewer launches with a single styled `(empty)` line; not an error. See `contracts/cli.md` "Empty input".
 - What happens when a file is deleted or its permissions change while the viewer is open? Existing buffer remains viewable; reload (`Ctrl-R`/`r`) surfaces the failure as a status-bar error and keeps the prior buffer.
@@ -193,17 +193,15 @@ A developer using the tool wants to know which file they're viewing, how many li
 - **SC-009**: For each fixture in `tests/fixtures/img/{small.png 32 KB, medium.jpg 5 MB, large.gif 49 MB}`, `spy <file>` in a Kitty-emulating PTY (a) emits a Kitty payload that round-trips through the harness's reference decoder back to a pixel-identical `image.Image`, (b) exits 0, (c) keeps resident memory ≤ 250 MB. Measured by `tests/integration/graphics_test.go` (extends T073).
 - **SC-010**: For `dummy.pdf` (single-page, known text "Dummy PDF file") and `tests/fixtures/pdf/multi-page.pdf` (3 pages), the renderer (a) rasterizes page 1 via `graphics.PDFPage` under `-tags fitz` in a graphics-capable PTY, and (b) extracts page text via `pdfcpu` in a non-graphics PTY — the extracted text MUST contain the known sentinel string. Measured by `tests/integration/pdf_test.go`.
 - **SC-011**: Three pipeline shapes pass end-to-end in `tests/e2e/05_pipe.sh`: (a) `cat tests/fixtures/hello.go | spy -l go` displays Go-highlighted content with `<stdin>` in the footer; (b) `git diff HEAD~ | spy` displays diff-highlighted content; (c) `grep -n needle tests/fixtures/hello.go | spy` displays plain text with `<stdin>` in the footer. All three exit 0 on `q`.
-- **SC-012**: Three independent reviewers (not the implementer) complete the `quickstart.md` Steps 2, 4, and 12 (open file, search + jump-to-line, resize) using only the in-app help overlay (`F1`/`?`); each reviewer records pass/fail and notes blockers in `specs/001-popup-reader/checklists/quickstart-validation.md`. Pass threshold: 3/3 reviewers pass all three steps without escaping to external docs. *Note*: original SC-012 ("90 % of users without docs") would require a funded user study with N ≥ 20; deferred to a post-v0.1.0 success metric. The reviewer-panel heuristic above is the v0.1.0 gate.
+- **SC-012**: A 3-reviewer panel — the implementer plus 2 independent reviewers (not the implementer) — each completes `quickstart.md` Steps 2, 4, and 12 (open file, search + jump-to-line, resize) using only the in-app help overlay (`F1`/`?`); each reviewer records pass/fail and notes blockers in `specs/001-popup-reader/checklists/quickstart-validation.md`. Pass threshold: 3/3 reviewers pass all three steps without escaping to external docs. *Note*: a stricter "all three external" panel and the funded user study (N ≥ 20) are deferred to v0.2.0+.
 
 ## Assumptions
 
 - **User Environment**: Users have access to a modern terminal emulator (xterm-compatible or better) with at least 256 colors support. Minimum supported dimensions are 80×24 (standard terminal); tool degrades gracefully below 80 columns or 8 rows. Extended image support (Kitty protocol, iTerm2) is optional but enables enhanced features.
 - **File System**: Spy operates on local files only; remote file systems (NFS, SSH) are out of scope for v1 but could be added if performance is acceptable.
 - **Scope - Text Focus**: The primary use case is text file review; PDF and image support is supplementary and can degrade gracefully.
-- **Large File Handling**: Files larger than 1GB should be handled via streaming or pagination; attempting to load entire file into memory is prohibited.
+- **Large Files**: All sources stream through the chunked loader so the initial viewport paints without waiting for full read. The windowed-mode threshold and resident-memory bound are pinned in **FR-012** (256 MiB → windowed; ≤ 1 GiB viewable; ≤ 500 MB RSS). Loading an entire file into memory is prohibited.
 - **Binary File Behavior**: Binary files will display a clear "unsupported format" message rather than attempting to render binary data.
 - **Terminal State Preservation**: The tool will restore terminal state (colors, cursor position, echo mode) on exit in all cases, even on error or signal.
 - **Configuration**: User preferences (theme, keybindings) can be configured via a simple config file (~/.spy/config) or environment variables; full config system design is out of scope for v1.
 - **Stdin Handling**: Piped input streams into the viewer through the same chunked loader as files (per FR-002 and US5 acceptance #1); content is held only in memory subject to the FR-012 resident-memory bound, and is never persisted to disk. Non-seekable stdin above the windowed-mode threshold falls back to scroll-forward-only mode with a status-bar warning (per FR-012).
-- **Large File Loading**: Large files (>100MB) use progressive/concurrent loading: initial viewport displays immediately while remaining content streams in background. No blocking waits for full file load.
-- **Keyboard Shortcuts**: Default keybindings use arrow keys for navigation (accessible to all users). Optional vim mode (hjkl, /, :) can be enabled via `--vim` flag or config file. Emacs keybindings and full customization out of scope for v1.

--- a/specs/001-popup-reader/tasks.md
+++ b/specs/001-popup-reader/tasks.md
@@ -90,7 +90,7 @@ completes. Each task pair below puts the failing test first.
 
 ### `internal/loader`
 
-- [ ] T020 [P] Write failing tests for `Open(ctx, src, cfg)` in `internal/loader/stream_test.go`: small file (one chunk + EOF), multi-chunk, empty file, cancellation via ctx, error propagation through `Errs` channel, first chunk synchronously available before return.
+- [ ] T020 [P] Write failing tests for `Open(ctx, src, cfg)` in `internal/loader/stream_test.go`: small file (one chunk + EOF), multi-chunk, empty file, cancellation via ctx, error propagation through `Errs` channel, first chunk synchronously available before return, **bounded `Updates` channel (default cap 4): producer blocks on send when consumer falls behind, verified via a slow-consumer test that asserts the producer goroutine is not at runtime.NumGoroutine higher than baseline + 2 after 1s of idle**.
 - [ ] T021 Implement `Chunk`, `Stream`, `Config`, and `Open(ctx, src, cfg)` in `internal/loader/stream.go` using `bufio.Scanner` with a 64 KiB read buffer. The first chunk is sized to ≥ `cfg.InitialChunkLines` (default = 2× viewport height = 80) so the first frame paints inside SC-001.
 - [ ] T022 [P] Write failing tests for windowed mode in `internal/loader/window_test.go`: trigger threshold via `cfg.MaxResidentBytes`, slice access reads-ahead, slice access for non-resident range re-seeks the source, stdin (non-seekable) falls back to "scroll forward only" with the documented warning.
 - [ ] T023 Implement windowing buffer (`Append`, `Slice`) and `MaxResidentBytes`-driven mode switch in `internal/loader/window.go`; emit `loader.WarnStdinNonSeekable` (a wrapped error sent on `Errs`) when stdin needs windowing.
@@ -234,12 +234,13 @@ graphics-capable terminal *and* one non-graphics terminal.
 
 ### Tests for User Story 4 ⚠️
 
-- [ ] T068 [P] [US4] Write failing unit tests for the Kitty encoder in `internal/graphics/kitty_test.go`: chunked base64 framing at 4096 B, escape sequence shape, `Cleanup` returns the documented "delete all images" sequence.
-- [ ] T069 [P] [US4] Write failing unit tests for the iTerm2 encoder in `internal/graphics/iterm2_test.go`: `\x1b]1337;File=…;preserveAspectRatio=1:<base64>\x07` shape.
-- [ ] T070 [P] [US4] Write failing unit tests for the sixel encoder in `internal/graphics/sixel_test.go`: round-trips a small in-memory PNG via `mattn/go-sixel`.
+- [ ] T068 [P] [US4] Write failing unit tests for the Kitty encoder in `internal/graphics/kitty_test.go`: chunked base64 framing at 4096 B, escape sequence shape, `Cleanup` returns the documented "delete all images" sequence, **full-payload golden test (T068b below)**.
+- [ ] T068b [P] [US4] Write failing golden-payload test in `internal/graphics/kitty_test.go`: encode a deterministic 16×16 PNG (checked into `internal/graphics/testdata/kitty_input.png`) and assert the **complete** escape stream byte-for-byte against `internal/graphics/testdata/kitty_expected.bin`. This catches malformed payloads between the `\x1b_G…` prefix and `\x1b\\` terminator that look correct under T068's prefix-only check but render as broken images.
+- [ ] T069 [P] [US4] Write failing unit tests for the iTerm2 encoder in `internal/graphics/iterm2_test.go`: `\x1b]1337;File=…;preserveAspectRatio=1:<base64>\x07` shape **plus full-payload golden test against `internal/graphics/testdata/iterm2_expected.bin`** using the same input PNG as T068b.
+- [ ] T070 [P] [US4] Write failing unit tests for the sixel encoder in `internal/graphics/sixel_test.go`: round-trips a small in-memory PNG via `mattn/go-sixel` **plus a full-payload golden test against `internal/graphics/testdata/sixel_expected.bin`** using the same input PNG. Note: sixel output may vary across `go-sixel` versions; pin the dep version in `go.mod` and document the regen procedure in `internal/graphics/testdata/README.md`.
 - [ ] T071 [P] [US4] Write failing tests for the `KindImage` renderer in `internal/render/image_test.go`: capable path emits the right protocol bytes; non-capable path emits a deterministic metadata block (filename, dimensions, size, fallback notice).
 - [ ] T072 [P] [US4] Write failing tests for the `KindPDF` renderer in `internal/render/pdf_test.go`: pdfcpu text extraction path returns page text; capable + `fitz` build tag triggers `graphics.PDFPage`; capable + `nofitz` build returns `ErrPDFGraphicsUnavailable` + falls back to text.
-- [ ] T073 [P] [US4] Write failing integration tests for graphics dispatch in `tests/integration/graphics_test.go`: assert that `term.Capabilities.Graphics == GraphicsKitty` produces the Kitty protocol bytes at the start of the rendered frame.
+- [ ] T073 [P] [US4] Write failing integration tests for graphics dispatch in `tests/integration/graphics_test.go`: assert that with `term.Capabilities.Graphics == GraphicsKitty` the rendered frame contains the **complete** Kitty payload (prefix `\x1b_G`, the same base64 chunks the unit-test golden produces, terminator `\x1b\\`) — not just the prefix. Diff against the same golden file as T068b. Repeat for iTerm2 and sixel paths.
 - [ ] T074 [P] [US4] Add failing E2E script `tests/e2e/04_graphics.sh` running `--graphics none` (forces metadata fallback) and `--graphics kitty` (forces Kitty encoder) against fixture image and PDF.
 
 ### Implementation for User Story 4
@@ -328,7 +329,13 @@ and close residual constitution TODOs.
 - [ ] T103 [P] Refresh the Constitution Check section in `specs/001-popup-reader/plan.md` to cite constitution v1.0.0 (closes `TODO(plan-001)` from `.specify/memory/constitution.md`).
 - [ ] T104 [P] Add SC-001 benchmark in `tests/perf/firstframe_bench_test.go`: load a 100-line file end-to-end and assert ≤ 100 ms.
 - [ ] T105 [P] Add SC-003 benchmark in `tests/perf/search_bench_test.go`: search across a 1 MiB synthetic file and assert ≤ 500 ms.
-- [ ] T106 [P] Add SC-005 benchmark in `tests/perf/large_file_test.go`: stream a 1 GiB synthetic file and assert RSS ≤ 500 MiB (skipped on CI by default; run via `-run TestLargeFile -tags perf`).
+- [ ] T106 [P] Add SC-005 benchmarks in `tests/perf/large_file_test.go` in **two tiers**:
+      (a) `TestLargeFile_PRGate`: 200 MiB synthetic file (just above the 256 MiB windowed-mode threshold's complement — the largest file that *doesn't* trigger windowing), asserts RSS ≤ 250 MiB. Runs on every PR (no build tag); ~5s on commodity CI; gates the PR.
+      (b) `TestLargeFile_Nightly`: 1 GiB synthetic file, asserts RSS ≤ 500 MiB. Behind `-tags perf`; CI runs it on a nightly schedule via `.github/workflows/nightly-perf.yml` against an `ubuntu-latest` runner with `RUNNER_OS_RAM_HINT=8192`. A failure files an issue tagged `perf-regression` rather than blocking PRs (because the nightly cadence makes blame attribution clear).
+      The PR-gate version catches algorithmic regressions; the nightly catches scaling-only regressions. SC-005's 1 GiB / 500 MiB promise is owned by (b).
+- [ ] T106a [P] Add SC-006 corpus + check in `tests/perf/highlight_corpus_test.go`: 50 source files under `tests/fixtures/highlight-corpus/` (one per GitHub Linguist top-50 language by repo count, each ≤ 4 KiB representative sample); assert Chroma selects a non-`fallback` lexer and ≤ 1 % of bytes per file land in `chroma.Error` tokens. Pass threshold: 47/50.
+- [ ] T106b [P] Add SC-007 dismiss benchmark in `tests/perf/dismiss_bench_test.go`: drive the PTY harness against `big.txt` 100 times, send `q`, measure wall-clock from keypress to `tea.Program.Run()` return; assert p95 ≤ 500 ms.
+- [ ] T106c [P] Add `.github/workflows/nightly-perf.yml`: scheduled `cron: '0 8 * * *'`, runs `make perf` (`go test -tags perf ./tests/perf/...`), uploads benchmark output as an artifact, opens an issue tagged `perf-regression` on failure (`peter-evans/create-issue-from-file@v5` or equivalent). Also add `make perf` target to `Makefile` (T003 add-on).
 - [ ] T107 [P] Run `reuse lint` and add SPDX headers to any files added across all phases that missed them. CI hook from T003 must pass.
 - [ ] T108 [P] Manual quickstart.md walkthrough on Linux/xterm; record results in `specs/001-popup-reader/checklists/quickstart-validation.md`.
 - [ ] T109 [P] Manual quickstart.md walkthrough on macOS/iTerm2 + Kitty; same checklist.

--- a/specs/001-popup-reader/tasks.md
+++ b/specs/001-popup-reader/tasks.md
@@ -1,0 +1,451 @@
+<!--
+SPDX-FileCopyrightText: 2026 Adam Poulemanos
+
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+# Tasks: Popup Reader
+
+**Input**: Design documents from `specs/001-popup-reader/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+**Constitution**: v1.0.0 (Principles I–VI, ratified 2026-04-25)
+
+**Tests**: REQUIRED. Constitution Principle II (Test-First Discipline) is
+NON-NEGOTIABLE. Every implementation task has a preceding failing-test task
+in the same logical change set. `go test ./... -race` and per-package
+coverage ≥ 80 % are gates on PR merge.
+
+**Organization**: Tasks are grouped by user story (P1 → P3) so each story can
+be implemented, tested, and demoed independently after Foundational completes.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel — different files, no dependencies on
+  incomplete tasks.
+- **[Story]**: Required for user-story-phase tasks (US1–US6). Setup,
+  Foundational, and Polish phases carry no story label.
+- File paths are concrete and match `contracts/internal-apis.md` and the
+  Project Structure section of `plan.md`.
+
+## Path Conventions
+
+Single Go module rooted at `/home/knitli/spy`:
+
+- Source: `cmd/spy/`, `internal/{term,source,loader,highlight,graphics,render,search,keys,config,ui}/`
+- Tests: `_test.go` siblings + `tests/integration/`, `tests/e2e/`
+- Examples: `examples/config.toml`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Bring the workspace into a state where any package below can
+compile, run tests with `-race`, and meet REUSE/SPDX requirements.
+
+- [ ] T001 Add new dependencies to `go.mod` and `go.sum`: `github.com/charmbracelet/bubbles`, `github.com/BurntSushi/toml`, `github.com/mattn/go-sixel`, `github.com/gen2brain/go-fitz`, `github.com/muesli/termenv`, `golang.org/x/term`. Run `go mod tidy` and verify pure-Go default build still compiles without `-tags fitz`.
+- [ ] T002 [P] Create new package skeleton directories with SPDX-headed `doc.go` for each: `internal/term/doc.go`, `internal/source/doc.go`, `internal/loader/doc.go`, `internal/highlight/doc.go`, `internal/graphics/doc.go`, `internal/render/doc.go`, `internal/search/doc.go`, `internal/keys/doc.go`. Each `doc.go` carries the dual-license SPDX header and a one-paragraph package summary.
+- [ ] T003 [P] Update `Makefile` with targets: `test` (`go test ./...`), `test-race` (`go test ./... -race`), `cover` (`go test ./... -race -coverprofile=coverage.out`), `lint` (`gofmt -l . && goimports -l .`), `vet` (`go vet ./...`), `build` (default), `build-fitz` (`-tags fitz`), `reuse` (`reuse lint`).
+- [ ] T004 [P] Create PTY harness skeleton in `tests/integration/pty.go` and `tests/integration/helpers.go` exposing `NewPTYProgram(t, args, env)` and golden-file diffing helpers; mark with SPDX header.
+- [ ] T005 [P] Create `tests/e2e/` directory with `tests/e2e/run.sh` shell harness that builds the binary and runs each `tests/e2e/NN_*.sh` script, plus `tests/e2e/fixtures/` and a `tests/e2e/setup.sh` that materializes `quickstart.md` Section 0 fixtures locally.
+- [ ] T006 [P] Author `examples/config.toml` matching the schema in `specs/001-popup-reader/contracts/config.md`, with all keys commented out at their default values plus three commented sample profiles (`theme = "dark"`; vim+regex+tight memory; per-language overrides).
+
+**Checkpoint**: `make test` passes against the unchanged skeleton; new
+packages compile (empty); REUSE lint passes.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Deliver every package and interface the user stories depend on,
+plus a minimum-viable plain-text viewer wired through the new architecture.
+After this phase, opening a `.txt` file with `spy` produces an alt-screen
+viewer with default arrow-key scrolling and clean exit on `q`/Esc/Ctrl-C —
+just no syntax highlighting yet (US1), no search (US2), no theme detection
+(US3), no graphics (US4), no stdin support (US5), no metadata footer (US6).
+
+**⚠️ CRITICAL**: User-story phases below MUST NOT begin until this phase
+completes. Each task pair below puts the failing test first.
+
+### `internal/keys`
+
+- [ ] T007 [P] Write failing table-driven tests for `Action` constants, `Default()` keymap, and key-binding parsing in `internal/keys/keymap_test.go` (every Action from `contracts/keys.md` must be present with correct default bindings).
+- [ ] T008 Implement `Action` type, exhaustive `Action*` constants, and `KeyMap` type in `internal/keys/keymap.go`; implement `Default()` populating arrow-key + named-key bindings via `bubbles/key.NewBinding` in `internal/keys/default.go`.
+- [ ] T009 [P] Write failing tests for `ApplyOverrides(km, map[string][]string)` covering known actions, unknown actions (warn-not-fail), unrecognised key strings, and idempotence; in `internal/keys/keymap_test.go`.
+- [ ] T010 Implement `ApplyOverrides` in `internal/keys/keymap.go` returning the merged keymap and a `[]error` slice for warnings; rejects unknown actions with a wrapped error using `%w`.
+
+### `internal/term`
+
+- [ ] T011 [P] Write failing tests for `Detect()` in `internal/term/capabilities_test.go` covering: TTY/non-TTY paths, env-var color depth (`COLORTERM=truecolor`, `TERM=*-256color`, neither), `NO_COLOR`, `KITTY_WINDOW_ID`, `TMUX`, `TERM_PROGRAM=iTerm.app|WezTerm`, dimension reporting, and override env vars (`SPY_GRAPHICS`, `SPY_THEME`).
+- [ ] T012 Implement `Capabilities`, `ColorDepth`, `Graphics` types and `Detect(ctx context.Context)` in `internal/term/capabilities.go`. Theme luminance probe is deferred to US3 — the field is `math.NaN()` here. Honour all override env vars; total probe budget ≤ 100 ms.
+- [ ] T013 [P] Write failing tests for `Restore()` in `internal/term/capabilities_test.go` (idempotence, no-op when stdout is not a TTY).
+- [ ] T014 Implement `Restore()` returning a closure that calls `term.Restore` on the saved state in `internal/term/capabilities.go`; `defer`-safe and idempotent.
+
+### `internal/source`
+
+- [ ] T015 [P] Write failing tests for `Kind` enum, magic-byte/extension/Chroma-match detection, and binary rejection (>1 % control bytes outside `\t\r\n\x1b` in first 8 KiB) in `internal/source/detect_test.go`. Cover Code (Go/Python/JS), Markdown, Text, PDF (`%PDF-` magic), Image (PNG/JPEG/GIF), Binary.
+- [ ] T016 Implement `Kind` constants and `detectKind(io.Reader, hint string) (Kind, string, error)` in `internal/source/detect.go` (returns kind + Chroma lexer name + error). Uses extension first, then magic bytes for PDF/image, then `lexers.Analyse`, then text/binary heuristic.
+- [ ] T017 [P] Write failing tests for `FileSource` in `internal/source/file_test.go`: regular file, broken symlink, permission denied, missing file. Each error must wrap one of `ErrNotFound`, `ErrPermission`, `ErrBinary`, `ErrUnsupported` so callers can `errors.Is`.
+- [ ] T018 Implement `Source` interface, `FileSource` struct, sentinel errors (`ErrNoInput`, `ErrBinary`, `ErrUnsupported`, `ErrNotFound`, `ErrPermission`), and `Metadata` struct in `internal/source/source.go` and `internal/source/file.go`. `Open()` returns a fresh `io.ReadCloser`; `Reopen()` returns an `io.ReadSeeker` for files.
+- [ ] T019 Implement `FromArgs(args []string, stdin *os.File, hint string) (Source, error)` in `internal/source/source.go` covering only file paths and explicit `-`; `StdinSource` construction is deferred to US5 (return `ErrNoInput` when stdin would be needed).
+
+### `internal/loader`
+
+- [ ] T020 [P] Write failing tests for `Open(ctx, src, cfg)` in `internal/loader/stream_test.go`: small file (one chunk + EOF), multi-chunk, empty file, cancellation via ctx, error propagation through `Errs` channel, first chunk synchronously available before return.
+- [ ] T021 Implement `Chunk`, `Stream`, `Config`, and `Open(ctx, src, cfg)` in `internal/loader/stream.go` using `bufio.Scanner` with a 64 KiB read buffer. The first chunk is sized to ≥ `cfg.InitialChunkLines` (default = 2× viewport height = 80) so the first frame paints inside SC-001.
+- [ ] T022 [P] Write failing tests for windowed mode in `internal/loader/window_test.go`: trigger threshold via `cfg.MaxResidentBytes`, slice access reads-ahead, slice access for non-resident range re-seeks the source, stdin (non-seekable) falls back to "scroll forward only" with the documented warning.
+- [ ] T023 Implement windowing buffer (`Append`, `Slice`) and `MaxResidentBytes`-driven mode switch in `internal/loader/window.go`; emit `loader.WarnStdinNonSeekable` (a wrapped error sent on `Errs`) when stdin needs windowing.
+
+### `internal/config`
+
+- [ ] T024 [P] Write failing tests for defaults, TOML parsing, env-var merge (`SPY_THEME`, `SPY_VIM`, `SPY_GRAPHICS`, `NO_COLOR`), flag merge precedence, `[keys]` table override, and per-language `[lang.<name>]` table — in `internal/config/load_test.go`. Include cases for unknown keys (warn), bad types (warn + default), missing file (silent OK).
+- [ ] T025 Replace `internal/config/config.go` with the full `Config` struct from `data-model.md` and a `Defaults()` constructor; implement `Load(opts LoadOptions) (*Config, []error)` in `internal/config/load.go` doing XDG lookup, TOML parse via `BurntSushi/toml`, env merge, flag merge — in that order — returning warnings (not errors) for soft failures.
+
+### `internal/render` (skeleton)
+
+- [ ] T026 [P] Write failing tests for `Renderer` interface dispatch via `ForKind` in `internal/render/renderer_test.go` covering all `source.Kind` values; the unsupported kinds return a no-op renderer that prints a warning frame.
+- [ ] T027 Implement `Renderer` interface, `Dependencies` struct, `ForKind(k source.Kind, deps Dependencies) Renderer`, and a passthrough `KindText` renderer (line numbers + soft-wrap + theme defaults; no syntax highlighting) in `internal/render/renderer.go`. Other kinds dispatch to stub renderers that emit a "unsupported in foundational; pending USx" frame; the stubs are replaced in their respective story phases.
+- [ ] T028 [P] Write failing tests for built-in dark/light `Theme` defaults in `internal/render/theme_test.go` (Chroma style resolution: `monokai` for dark, `github` for light; fallback when an unknown style name is requested).
+- [ ] T029 Implement `Theme` struct and `Theme{Dark,Light}()` constructors plus `ResolveTheme(cfg, caps) Theme` placeholder (the auto-detect branch falls back to dark until US3) in `internal/render/theme.go`.
+
+### `cmd/spy` rewiring
+
+- [ ] T030 [P] Write failing tests for flag parsing in `cmd/spy/flags_test.go` — every flag from `contracts/cli.md` (long + short forms), env var fallback, `--help` / `--version` exits, `--config` vs `--no-config` mutual exclusion, unknown flag → exit 2.
+- [ ] T031 Extract flag definitions into `cmd/spy/flags.go` exposing `ParseFlags([]string) (*ParsedFlags, error)`; pure (no side effects) so it's testable.
+- [ ] T032 Replace `cmd/spy/main.go` with the foundational wiring: `term.Detect` → `config.Load` → `source.FromArgs` → `loader.Open` → `ui.NewModel` → `tea.NewProgram(model, tea.WithAltScreen()).Run()`. Implement FR-013 stderr error path with the documented exit codes (0/1/2/3/4/5/130/143) and the `spy: <reason>: <detail>` format from `contracts/cli.md`. `defer term.Restore()` belt-and-suspenders.
+
+### `internal/ui` rewiring
+
+- [ ] T033 [P] Write failing tests for `NewModel`, `Init`, `Update` (handles `tea.WindowSizeMsg`, `chunkLoadedMsg`, key events), and `View` in `internal/ui/model_test.go`. Cover: foundational quit on `q`/Esc/Ctrl-C, scroll up/down with arrow keys, end-of-file indicator on last line, resize reflows viewport.
+- [ ] T034 Replace `internal/ui/model.go` with a `bubbles/viewport`-based `Model`, `NewModel(opts ModelOptions) Model`, `ModelOptions` matching `contracts/internal-apis.md`, and the foundational `Init`/`Update`/`View`. Wire the `internal/keys.Default()` keymap; vim mode is added in US2.
+- [ ] T035 [P] Split UI into `internal/ui/update.go`, `internal/ui/view.go`, `internal/ui/help.go` (help is a stub overlay until later stories add bindings to surface).
+
+### Cleanup of legacy skeleton
+
+- [ ] T036 Delete `internal/reader/` and `internal/renderer/` packages. Move any still-useful utilities into the appropriate new package (`internal/source`, `internal/render`); update all imports under `cmd/spy/` and tests. After this task, `grep -r "internal/reader\|internal/renderer" .` returns no hits.
+
+**Checkpoint**: `make test-race` and `make cover` pass at ≥ 80 % per package.
+`spy /etc/hosts` shows the file in alt-screen, scrolls with arrow keys, and
+exits cleanly with `q`. No syntax highlighting, no search, no graphics yet.
+
+---
+
+## Phase 3: User Story 1 - Quick Text Review with Syntax Highlighting (Priority: P1) 🎯 MVP
+
+**Goal**: Open a code or markdown file with `spy file.go` and see proper
+syntax highlighting in an alt-screen popup; dismiss with `q`/Esc.
+
+**Independent Test**: Run `spy cmd/spy/main.go` and visually verify Go syntax
+colours; run `spy README.md` and verify Glamour-rendered headings/lists. Run
+the matching golden-file integration test.
+
+### Tests for User Story 1 ⚠️ (write first, FAIL before implementation)
+
+- [ ] T037 [P] [US1] Write failing tests for `Highlighter` in `internal/highlight/highlighter_test.go`: lexer auto-selection by language hint, fallback to plain text on unknown lexer, `HighlightCap` short-circuit (returns `Token{Type: Text}` for the whole line above the cap), streaming behaviour over a chunk channel.
+- [ ] T038 [P] [US1] Write failing tests for the `KindCode` renderer in `internal/render/code_test.go`: ANSI output matches a golden file under `tests/integration/golden/hello_go_dark.txt`, line-number column rendering, `--no-line-numbers` honoured, soft-wrap behaviour.
+- [ ] T039 [P] [US1] Write failing tests for the `KindMarkdown` renderer in `internal/render/markdown_test.go`: Glamour rendering of headings/lists/code blocks against a golden file under `tests/integration/golden/sample_md.txt`.
+- [ ] T040 [P] [US1] Write a failing integration test in `tests/integration/text_review_test.go` driving the PTY harness against a small Go file: assert highlighted output, scroll-down behaviour, `q` exit.
+- [ ] T041 [P] [US1] Add a failing E2E script `tests/e2e/01_text_review.sh` invoking the built binary against `tests/e2e/fixtures/hello.go`, snapshotting the alt-screen frame via the harness, and diffing against a golden screen.
+
+### Implementation for User Story 1
+
+- [ ] T042 [US1] Implement `Highlighter`, `New(theme, depth, capBytes)`, `Highlight(lang, line)`, and `HighlightStream(ctx, in, out)` in `internal/highlight/highlighter.go` using `chroma/v2` lexers + `formatters.TTY256`/`TrueColour` selected from `term.ColorDepth`. Honour `HighlightCap` from config (above-cap → no-op).
+- [ ] T043 [US1] Replace the `KindCode` stub with the real renderer in `internal/render/code.go`: consumes `[]source.Token` from the highlighter (or raw `Line.Raw` when `Tokens == nil`), formats with `lipgloss.Style` for line numbers, soft-wraps at viewport width when `Config.WordWrap` is true.
+- [ ] T044 [US1] Replace the `KindMarkdown` stub with a Glamour-backed renderer in `internal/render/markdown.go`. Pick the Glamour style from the active `Theme` (dark → `dark`, light → `light`). Disable Glamour when stdout color depth is `Mono`.
+- [ ] T045 [US1] Update `internal/ui/Model.Update` in `internal/ui/update.go` to:
+      (a) feed loader chunks through `Highlighter.HighlightStream` when `source.Kind == KindCode`,
+      (b) trigger a re-render frame on `chunkLoadedMsg` so highlighted content appears progressively,
+      (c) display "END" indicator (`render.Theme.Footer`) when the viewport reaches the last loaded line and `Status == Ready`.
+- [ ] T046 [US1] Wire alt-screen entry/exit options in `cmd/spy/main.go`: `tea.WithAltScreen()`, `tea.WithMouseCellMotion()`, and a SIGWINCH-aware program option. Confirm `defer term.Restore()` still fires on panic.
+
+**Checkpoint**: User Story 1 is fully functional. Steps 2 and 12 of
+`quickstart.md` pass. MVP is shippable here.
+
+---
+
+## Phase 4: User Story 2 - Code Navigation: Search + Jump-to-Line (Priority: P1)
+
+**Goal**: While viewing a file, search forward/backward (`/`, `?`), navigate
+matches (`n`/`N`), and jump to a line (`:N`). Vim mode (`--vim`) adds the
+familiar additive bindings.
+
+**Independent Test**: Open `big.txt` (10 000 lines), `/9999<Enter>` jumps and
+highlights the match; `:1<Enter>` returns to top; `:$<Enter>` jumps to end.
+With `--vim`, `gg`/`G`/`Ctrl-D`/`Ctrl-U` work as expected.
+
+### Tests for User Story 2 ⚠️
+
+- [ ] T047 [P] [US2] Write failing tests for `Compile` and `Matcher` in `internal/search/matcher_test.go`: literal substring, regex (`--regex` and `\v` prefix), case modes (smart/sensitive/insensitive), invalid regex returns error.
+- [ ] T048 [P] [US2] Write failing tests for `Scan` in `internal/search/search_test.go`: forward/backward scanning, wrap-around detection, cancellation via ctx, partial matches across windowed-mode line buffers.
+- [ ] T049 [P] [US2] Write failing tests for `WithVim(km KeyMap)` in `internal/keys/keymap_test.go`: vim bindings are additive (default arrows still work), `gg`/`G`/`Ctrl-D`/`Ctrl-U`/`0`/`$`/`h`/`j`/`k`/`l` resolve to the right `Action`.
+- [ ] T050 [P] [US2] Write failing tests for command-line state machine in `internal/ui/update_test.go`: `:N` jumps, `:0`/`:$` aliases, out-of-range clamps to last loaded line + status warning, `:set vim` toggles, `:set theme dark|light|auto`, `:open <path>` swaps source, unknown command warns.
+- [ ] T051 [P] [US2] Write a failing integration test in `tests/integration/search_test.go`: PTY drives `/9999\n`, asserts viewport scrolled to that line, `n` wraps with status message.
+- [ ] T052 [P] [US2] Add failing E2E script `tests/e2e/02_search_navigation.sh` covering search forward/backward, jump-to-line, `:0`/`:$`, vim mode (run twice with and without `--vim`).
+
+### Implementation for User Story 2
+
+- [ ] T053 [US2] Implement `Compile`, `Matcher`, `CaseMode` in `internal/search/matcher.go` (smart-case heuristic: lowercase query → case-insensitive; otherwise sensitive). Regex path uses `regexp` stdlib; literal path uses `strings.Contains`-style scan for performance.
+- [ ] T054 [US2] Implement `Scan(ctx, lines, m, dir, from)` returning a `<-chan Match` in `internal/search/search.go`. Honour cancellation; emit a synthetic `Wrapped` marker as the last channel value before close.
+- [ ] T055 [US2] Implement `WithVim(km) KeyMap` in `internal/keys/vim.go` adding the additive bindings; tests T049 must pass.
+- [ ] T056 [US2] Add `SearchState` and `CommandLineState` to `internal/ui/Model` and implement the `:` / `/` / `?` prompt state machine in `internal/ui/update.go`: prompt-open captures keystrokes, `Enter` submits, `Esc` cancels, history via Up/Down arrows.
+- [ ] T057 [US2] Wire match navigation: highlight `SearchHit`/`SearchActive` regions in `internal/render/code.go` and `internal/render/markdown.go` (markdown highlight is best-effort over the rendered line). On `n`/`N` move `CurrentMatch`; on wrap, set the status bar to "search wrapped".
+- [ ] T058 [US2] Implement command handlers (`:N`, `:0`, `:$`, `:set vim`, `:set novim`, `:set theme …`, `:open <path>`, `:q`/`:quit`) in `internal/ui/update.go`. `:open` reuses `loader.Open` + `source.FromArgs`.
+- [ ] T059 [US2] Wire `--vim` flag and `vim_mode = true` config to invoke `keys.WithVim(km)` in `cmd/spy/main.go`. `:set vim` at runtime swaps the active keymap.
+
+**Checkpoint**: User Story 2 is functional. Steps 4 and 5 of `quickstart.md`
+pass. The viewer now supports search, jump, and vim mode.
+
+---
+
+## Phase 5: User Story 3 - Dark/Light Theme Detection + Override (Priority: P1)
+
+**Goal**: Spy auto-detects the terminal background luminance and picks a
+readable theme; `--theme` / `SPY_THEME` / config file overrides win.
+
+**Independent Test**: Steps 6 and 15 of `quickstart.md` pass; `:set theme
+light` at runtime visibly switches.
+
+### Tests for User Story 3 ⚠️
+
+- [ ] T060 [P] [US3] Write failing tests for OSC 11 query + `COLORFGBG` fallback in `internal/term/theme_test.go` (mock the response stream; assert luminance ≥ 0.5 → light, < 0.5 → dark, malformed → NaN, timeout → NaN).
+- [ ] T061 [P] [US3] Write failing tests for `ResolveTheme(cfg, caps)` in `internal/render/theme_test.go`: `auto` + light caps → light theme; `auto` + dark caps → dark theme; `auto` + NaN luminance → dark fallback; explicit `light`/`dark`/`<chroma-style>` always wins.
+- [ ] T062 [P] [US3] Write a failing integration test in `tests/integration/theme_test.go` using a fake PTY that replies to OSC 11 with a light-grey colour, asserting the rendered ANSI uses the `github` Chroma style.
+- [ ] T063 [P] [US3] Add failing E2E script `tests/e2e/03_theme.sh` covering `--theme dark`, `--theme light`, `SPY_THEME=light`, `NO_COLOR=1` (forces mono).
+
+### Implementation for User Story 3
+
+- [ ] T064 [US3] Implement OSC 11 luminance probe via `muesli/termenv`'s `BackgroundColor()` in `internal/term/theme.go`, with a 50 ms total timeout and `COLORFGBG` env-var fallback.
+- [ ] T065 [US3] Wire `BackgroundLuminance` into `term.Detect()` (replacing the `NaN` placeholder from T012). Honour `SPY_THEME` to short-circuit the probe entirely.
+- [ ] T066 [US3] Replace the placeholder `ResolveTheme` from T029 with the full implementation in `internal/render/theme.go`: respects `cfg.Theme` (`auto`/`dark`/`light`/named Chroma style), `caps.BackgroundLuminance`, and `cfg.NoColor` (forces a Mono theme that disables Chroma styling).
+- [ ] T067 [US3] Wire runtime theme swap (`:set theme …` from T058) to `ResolveTheme` and re-render in `internal/ui/update.go`; the in-memory token buffer is reused — only the formatter changes.
+
+**Checkpoint**: User Story 3 is functional. Steps 6 and 15 of `quickstart.md`
+pass. P1 stories (US1, US2, US3) all green.
+
+---
+
+## Phase 6: User Story 4 - PDF and Image Support (Priority: P2)
+
+**Goal**: In capable terminals (Kitty / iTerm2 / WezTerm / sixel), render
+images inline and rasterize PDF pages. In other terminals, fall back to
+metadata blocks (image) or text extraction (PDF) without crashing.
+
+**Independent Test**: Steps 7 and 8 of `quickstart.md` pass on at least one
+graphics-capable terminal *and* one non-graphics terminal.
+
+### Tests for User Story 4 ⚠️
+
+- [ ] T068 [P] [US4] Write failing unit tests for the Kitty encoder in `internal/graphics/kitty_test.go`: chunked base64 framing at 4096 B, escape sequence shape, `Cleanup` returns the documented "delete all images" sequence.
+- [ ] T069 [P] [US4] Write failing unit tests for the iTerm2 encoder in `internal/graphics/iterm2_test.go`: `\x1b]1337;File=…;preserveAspectRatio=1:<base64>\x07` shape.
+- [ ] T070 [P] [US4] Write failing unit tests for the sixel encoder in `internal/graphics/sixel_test.go`: round-trips a small in-memory PNG via `mattn/go-sixel`.
+- [ ] T071 [P] [US4] Write failing tests for the `KindImage` renderer in `internal/render/image_test.go`: capable path emits the right protocol bytes; non-capable path emits a deterministic metadata block (filename, dimensions, size, fallback notice).
+- [ ] T072 [P] [US4] Write failing tests for the `KindPDF` renderer in `internal/render/pdf_test.go`: pdfcpu text extraction path returns page text; capable + `fitz` build tag triggers `graphics.PDFPage`; capable + `nofitz` build returns `ErrPDFGraphicsUnavailable` + falls back to text.
+- [ ] T073 [P] [US4] Write failing integration tests for graphics dispatch in `tests/integration/graphics_test.go`: assert that `term.Capabilities.Graphics == GraphicsKitty` produces the Kitty protocol bytes at the start of the rendered frame.
+- [ ] T074 [P] [US4] Add failing E2E script `tests/e2e/04_graphics.sh` running `--graphics none` (forces metadata fallback) and `--graphics kitty` (forces Kitty encoder) against fixture image and PDF.
+
+### Implementation for User Story 4
+
+- [ ] T075 [US4] Implement the Kitty graphics encoder in `internal/graphics/kitty.go` (~80 LOC, chunked base64 framing) and the cleanup escape.
+- [ ] T076 [US4] Implement the iTerm2 inline-image encoder in `internal/graphics/iterm2.go`.
+- [ ] T077 [US4] Implement the sixel encoder wrapper around `mattn/go-sixel` in `internal/graphics/sixel.go` (uses `golang.org/x/image` for source decoding).
+- [ ] T078 [US4] Implement `Render(proto, img, cols, rows)` and `Cleanup(proto)` dispatchers in `internal/graphics/graphics.go`.
+- [ ] T079 [US4] Implement build-tag-gated `internal/graphics/pdf_fitz.go` (build tag `fitz`) using `gen2brain/go-fitz` to rasterize a single page to `image.Image`; and `internal/graphics/pdf_nofitz.go` (build tag `!fitz`) returning the documented sentinel `ErrPDFGraphicsUnavailable`.
+- [ ] T080 [US4] Replace the `KindImage` stub in `internal/render/image.go`: capable terminals → `graphics.Render`; otherwise the metadata fallback block. Re-open the file at render time (per `research.md` R2) to keep memory under SC-005.
+- [ ] T081 [US4] Replace the `KindPDF` stub in `internal/render/pdf.go`: pdfcpu page-text extraction by default; on graphics-capable terminals AND `fitz` build, rasterize the current page and render via `graphics.Render`. Track `Page` index in the renderer state.
+- [ ] T082 [US4] Wire `]` / `[` page navigation when `source.Kind == KindPDF` and `:N` for page-jump (re-using the command-line state from T056) in `internal/ui/update.go`.
+- [ ] T083 [US4] Wire Kitty "delete all images" cleanup on `tea.Quit` and on source replacement (`:open`) in `internal/ui/update.go` — call `graphics.Cleanup(caps.Graphics)` and write its output via a `tea.Cmd` before the model exits.
+- [ ] T084 [US4] Honour `--graphics` flag and `SPY_GRAPHICS` env via the merge order from T024 (CLI > env > config > auto-detect). `--graphics none` short-circuits all encoding.
+
+**Checkpoint**: User Story 4 is functional. Steps 7 and 8 of `quickstart.md`
+pass on both graphics-capable and non-graphics terminals; default and
+`-tags fitz` builds both compile and behave per the contract.
+
+---
+
+## Phase 7: User Story 5 - Pipe Input Support (Priority: P2)
+
+**Goal**: `git diff | spy` and `cat file.go | spy -l go` work the same way
+they do in `bat` — content streams from stdin, never touches disk, and
+language is auto-detected (shebang, hint, Chroma `Analyse`).
+
+**Independent Test**: Step 3 of `quickstart.md` passes.
+
+### Tests for User Story 5 ⚠️
+
+- [ ] T085 [P] [US5] Write failing tests for `StdinSource` in `internal/source/stdin_test.go`: `Open()` returns the underlying reader, `Reopen()` returns `nil, ErrNotSeekable`, `DisplayName()` is `<stdin>`.
+- [ ] T086 [P] [US5] Write failing tests for stdin language inference in `internal/source/detect_test.go`: shebang first line, `--lang` hint override, Chroma `Analyse` fallback, plain text when none match.
+- [ ] T087 [P] [US5] Write failing tests for `FromArgs` stdin construction in `internal/source/source_test.go`: TTY stdin + no file → `ErrNoInput`; non-TTY stdin + no file → `StdinSource`; `-` positional + TTY stdin → `StdinSource` (blocks per contract); both file and stdin → file wins.
+- [ ] T088 [P] [US5] Write a failing integration test in `tests/integration/stdin_test.go`: PTY pair, write a Go diff to stdin, assert highlighted-diff output and `<stdin>` in the footer.
+- [ ] T089 [P] [US5] Add failing E2E script `tests/e2e/05_pipe.sh`: `git diff HEAD~ | spy` (when run inside a git repo), `echo content | spy -`, and the degenerate-cat mode (`echo content | spy | cat`) which must exit 0 and pass content through verbatim with no escape sequences.
+
+### Implementation for User Story 5
+
+- [ ] T090 [US5] Implement `StdinSource` in `internal/source/stdin.go`. `Open()` returns an `io.NopCloser(os.Stdin)`-like reader that's safe to close; `Reopen()` returns `nil, ErrNotSeekable`.
+- [ ] T091 [US5] Update `FromArgs` (T019) to construct `StdinSource` when stdin is non-TTY and no file argument; honour the `-` positional explicitly.
+- [ ] T092 [US5] Update `detectKind` (T016) to support stdin: read the first 8 KiB into a `bytes.Buffer`, detect, then prepend the buffered bytes back into the stream via a `MultiReader`.
+- [ ] T093 [US5] Implement degenerate-cat mode in `cmd/spy/main.go`: when stdin is consumed AND stdout is not a TTY, copy the input verbatim to stdout and exit 0 (no alt-screen). This is the contract from `contracts/cli.md` "stdin behavior".
+- [ ] T094 [US5] Update the footer/`DisplayName` plumbing so stdin sessions show `<stdin>` instead of a basename — touches `internal/render/statusbar.go` (still a stub at this point; full footer is US6).
+
+**Checkpoint**: User Story 5 is functional. Step 3 of `quickstart.md` passes.
+
+---
+
+## Phase 8: User Story 6 - File Metadata Footer (Priority: P3)
+
+**Goal**: A status bar at the bottom of the viewer shows
+`<displayname> | <total> lines | Line <current>` (or `Page m/n` for PDFs),
+updates on scroll/resize, collapses gracefully under 80 columns.
+
+**Independent Test**: Step 2 (footer line count + position) and step 14
+(minimum-size degradation) of `quickstart.md` pass.
+
+### Tests for User Story 6 ⚠️
+
+- [ ] T095 [P] [US6] Write failing tests for `statusbar.Render(meta, viewport)` in `internal/render/statusbar_test.go`: standard format, streaming-mode `…` indicator while `LineCount == -1`, PDF page indicator, sub-80-column collapse to single short line.
+- [ ] T096 [P] [US6] Write a failing integration test in `tests/integration/footer_test.go` driving the PTY through scroll-down and asserting the line counter advances correctly.
+- [ ] T097 [P] [US6] Add failing E2E script `tests/e2e/06_footer.sh` covering scrolling end-to-end, resize, and the sub-80-column degraded layout.
+
+### Implementation for User Story 6
+
+- [ ] T098 [US6] Implement `statusbar.Render(meta source.Metadata, vp viewport.Model, theme Theme) string` in `internal/render/statusbar.go`. Use `lipgloss` styles from the active `Theme`. Below 80 cols, emit only `<short-name> · L<current>`.
+- [ ] T099 [US6] Wire the statusbar into `internal/ui/View` in `internal/ui/view.go` so it renders on every frame; subscribe to `tea.WindowSizeMsg` for width updates.
+- [ ] T100 [US6] Update `loader.Stream` to surface `LineCount` updates (post a `metaUpdatedMsg{TotalLines int64}` on EOF) so the footer can switch from `…` to the final count without re-rendering everything.
+
+**Checkpoint**: All P1/P2/P3 stories functional. `quickstart.md` Steps 1–15
+all pass on a Linux + xterm-compatible terminal.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Lock in non-functional requirements, finalize documentation,
+and close residual constitution TODOs.
+
+- [ ] T101 [P] Refresh `README.md` to describe `spy` (not the placeholder text), with a quick install + usage section linking to `specs/001-popup-reader/contracts/cli.md`, `keys.md`, and `config.md`.
+- [ ] T102 [P] Update `DEVELOPMENT.md` with `make` target descriptions, the `-tags fitz` build instructions, and a brief on the `tests/integration` PTY harness.
+- [ ] T103 [P] Refresh the Constitution Check section in `specs/001-popup-reader/plan.md` to cite constitution v1.0.0 (closes `TODO(plan-001)` from `.specify/memory/constitution.md`).
+- [ ] T104 [P] Add SC-001 benchmark in `tests/perf/firstframe_bench_test.go`: load a 100-line file end-to-end and assert ≤ 100 ms.
+- [ ] T105 [P] Add SC-003 benchmark in `tests/perf/search_bench_test.go`: search across a 1 MiB synthetic file and assert ≤ 500 ms.
+- [ ] T106 [P] Add SC-005 benchmark in `tests/perf/large_file_test.go`: stream a 1 GiB synthetic file and assert RSS ≤ 500 MiB (skipped on CI by default; run via `-run TestLargeFile -tags perf`).
+- [ ] T107 [P] Run `reuse lint` and add SPDX headers to any files added across all phases that missed them. CI hook from T003 must pass.
+- [ ] T108 [P] Manual quickstart.md walkthrough on Linux/xterm; record results in `specs/001-popup-reader/checklists/quickstart-validation.md`.
+- [ ] T109 [P] Manual quickstart.md walkthrough on macOS/iTerm2 + Kitty; same checklist.
+- [ ] T110 Add a `CHANGELOG.md` `0.1.0` entry summarizing US1–US6.
+- [ ] T111 Final gate: `make lint vet test-race cover` clean, per-package coverage ≥ 80 %, `reuse lint` clean, default and `-tags fitz` builds both succeed.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: no dependencies; can start immediately.
+- **Phase 2 (Foundational)**: depends on Phase 1. Blocks everything below.
+- **Phase 3 (US1)**: depends on Phase 2 only.
+- **Phase 4 (US2)**: depends on Phase 2 only. May land before or after US1 in
+  parallel-team layouts; in solo-MVP mode it follows US1.
+- **Phase 5 (US3)**: depends on Phase 2 only. The `auto` theme path produces
+  identical output to the foundational `dark` default until US3 lands, so
+  the order between US1/US2/US3 is interchangeable.
+- **Phase 6 (US4)**: depends on Phase 2 only. Plain-text/code/markdown
+  rendering keeps working without it.
+- **Phase 7 (US5)**: depends on Phase 2 only. Files keep working without it.
+- **Phase 8 (US6)**: depends on Phase 2; benefits from US5 for the
+  `<stdin>` display name but does not require it.
+- **Phase 9 (Polish)**: depends on whichever stories are in scope for the
+  release; T103 specifically depends on Phase 2 being done.
+
+### Within Each Phase
+
+- Tests (Tnnn-test) MUST be written and FAIL before the matching impl task
+  (constitution Principle II).
+- Within Phase 2, the order is: keys → term → source → loader → config →
+  render skeleton → cmd/spy/flags → cmd/spy/main → ui → cleanup.
+- Within Phase 6 (US4), the per-protocol encoders (T075, T076, T077) are
+  parallelizable; T078 depends on all three; T079 is `fitz`-build-tag
+  isolated and can be done in parallel with T080–T082.
+
+### Parallel Opportunities
+
+- **All Phase 1 setup tasks** marked [P] (T002–T006) run in parallel.
+- **Within Phase 2**, the test-writing tasks across packages
+  (T007/T011/T015/T020/T024/T026/T028/T030/T033) are parallelizable; their
+  matching impl tasks are sequential within their package.
+- **Across user stories**, with multiple developers: US1, US2, US3, US4,
+  US5, and US6 can run concurrently after Phase 2 completes. The only
+  cross-story coupling is in `internal/ui/update.go`, which is touched by
+  US1, US2, US4, and US6 — coordinate via small commits and rebase.
+- **All Polish tasks** marked [P] (T101–T109) run in parallel.
+
+### Parallel Example: User Story 1
+
+```bash
+# Phase 3: launch all US1 test-writing tasks together
+Task: "Write failing tests for Highlighter in internal/highlight/highlighter_test.go (T037)"
+Task: "Write failing tests for KindCode renderer in internal/render/code_test.go (T038)"
+Task: "Write failing tests for KindMarkdown renderer in internal/render/markdown_test.go (T039)"
+Task: "Write failing integration test in tests/integration/text_review_test.go (T040)"
+Task: "Add failing E2E script tests/e2e/01_text_review.sh (T041)"
+```
+
+After tests are red, sequential within a single feature surface:
+
+```bash
+T042 (Highlighter impl) → T043 (KindCode impl) → T044 (KindMarkdown impl)
+                              ↓                          ↓
+                              T045 (UI streaming highlight) → T046 (alt-screen wiring)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (User Story 1 only)
+
+1. Phase 1 Setup (T001–T006).
+2. Phase 2 Foundational (T007–T036).
+3. Phase 3 US1 (T037–T046).
+4. **STOP and validate**: `quickstart.md` Step 2 passes. Demo.
+
+This is a shippable popup file viewer with syntax highlighting and clean
+exit — already differentiated from `cat`/`less`.
+
+### Recommended Incremental Delivery
+
+1. MVP (above) → demo.
+2. Add US3 (theme detection) → demo on light + dark terminals.
+3. Add US2 (search + jump + vim) → demo full review workflow.
+4. Add US5 (pipe input) → demo `git diff | spy`.
+5. Add US4 (PDF + image) → demo on Kitty/iTerm2.
+6. Add US6 (footer metadata) → demo polished status bar.
+7. Phase 9 Polish → cut `0.1.0` tag.
+
+### Parallel Team Strategy
+
+After Phase 2, partition by story and let each track land independently:
+
+- Dev A: US1 (T037–T046)
+- Dev B: US2 (T047–T059)
+- Dev C: US3 (T060–T067)
+- Dev D: US4 (T068–T084)
+- Dev E: US5 (T085–T094)
+- Dev F: US6 (T095–T100)
+
+The only shared file requiring coordination is `internal/ui/update.go` —
+keep US-specific edits in tight commits and rebase frequently.
+
+---
+
+## Notes
+
+- `[P]` = different files, no incomplete dependencies.
+- `[USn]` traces a task to its user story.
+- Every implementation task has a preceding failing test task (constitution
+  Principle II, NON-NEGOTIABLE).
+- Commit after each task or logical group; auto-commit hooks are configured
+  (currently disabled) at `.specify/extensions/git/git-config.yml`.
+- `quickstart.md` is the source of truth for end-to-end validation; the
+  Polish phase makes the manual walkthrough mandatory before tagging.
+- Build-tag note: by default `go build ./cmd/spy` produces a pure-Go binary;
+  `go build -tags fitz ./cmd/spy` enables PDF rasterization via go-fitz/cgo.
+- Avoid: vague tasks, same-file conflicts across [P] siblings, cross-story
+  imports that break independent shippability.

--- a/specs/001-popup-reader/tasks.md
+++ b/specs/001-popup-reader/tasks.md
@@ -94,6 +94,8 @@ completes. Each task pair below puts the failing test first.
 - [ ] T021 Implement `Chunk`, `Stream`, `Config`, and `Open(ctx, src, cfg)` in `internal/loader/stream.go` using `bufio.Scanner` with a 64 KiB read buffer. The first chunk is sized to ≥ `cfg.InitialChunkLines` (default = 2× viewport height = 80) so the first frame paints inside SC-001.
 - [ ] T022 [P] Write failing tests for windowed mode in `internal/loader/window_test.go`: trigger threshold via `cfg.MaxResidentBytes`, slice access reads-ahead, slice access for non-resident range re-seeks the source, stdin (non-seekable) falls back to "scroll forward only" with the documented warning.
 - [ ] T023 Implement windowing buffer (`Append`, `Slice`) and `MaxResidentBytes`-driven mode switch in `internal/loader/window.go`; emit `loader.WarnStdinNonSeekable` (a wrapped error sent on `Errs`) when stdin needs windowing.
+- [ ] T023b [P] Failing tests in `internal/loader/stream_test.go` for per-line cap (covers spec.md edge case "lines longer than 100 KiB are truncated at 100 KiB"): a synthetic input line of 200 KiB results in `Line.Raw` of exactly 102400 bytes, and the `Stream.Errs` channel emits `loader.WarnLineTruncated{Line int64, OriginalBytes int}` exactly once for that line; cap is configurable via `cfg.MaxLineBytes` (default 102400). Also covers a 5 MiB synthetic line (truncated identically) and an empty line (untouched).
+- [ ] T023c Implement per-line truncation in `internal/loader/stream.go`: pass `cfg.MaxLineBytes` (default 102400) to the `bufio.Scanner.Buffer(...)` setup and post-process tokens longer than the cap by truncating to cap and emitting `WarnLineTruncated` (a wrapped error) on `Stream.Errs`. Add `MaxLineBytes int64` to `loader.Config` (already documented in `contracts/internal-apis.md`). Surface the warning through the standard status-bar advisory pipeline (5 s auto-clear), reusing the same path as `WarnHighlightDisabled`.
 
 ### `internal/config`
 
@@ -118,6 +120,7 @@ completes. Each task pair below puts the failing test first.
 - [ ] T033 [P] Write failing tests for `NewModel`, `Init`, `Update` (handles `tea.WindowSizeMsg`, `chunkLoadedMsg`, key events), and `View` in `internal/ui/model_test.go`. Cover: foundational quit on `q`/Esc/Ctrl-C, scroll up/down with arrow keys, end-of-file indicator on last line, resize reflows viewport.
 - [ ] T034 Replace `internal/ui/model.go` with a `bubbles/viewport`-based `Model`, `NewModel(opts ModelOptions) Model`, `ModelOptions` matching `contracts/internal-apis.md`, and the foundational `Init`/`Update`/`View`. Wire the `internal/keys.Default()` keymap; vim mode is added in US2.
 - [ ] T035 [P] Split UI into `internal/ui/update.go`, `internal/ui/view.go`, `internal/ui/help.go` (help is a stub overlay until later stories add bindings to surface).
+- [ ] T035b [P] Failing integration test in `tests/integration/signal_test.go` driving the PTY harness against `/tmp/spy-fixtures/big.txt` (covers FR-015 / SC-008 signal-handling gate that Constitution Principle II requires): once the alt-screen frame is observed, send SIGINT and assert (a) process exits with code 130 within 1 s, (b) terminal modes restored (echo on, cursor visible, alt-screen exited via the `\x1b[?1049l` sequence), (c) no residual escape sequences trail on stdout. Repeat the run sending SIGTERM and assert exit code 143. Graphics-cleanup assertions deferred to T083; this task only covers the foundational `defer term.Restore()` chain from T032.
 
 ### Cleanup of legacy skeleton
 
@@ -156,6 +159,8 @@ the matching golden-file integration test.
       (b) trigger a re-render frame on `chunkLoadedMsg` so highlighted content appears progressively,
       (c) display "END" indicator (`render.Theme.Footer`) when the viewport reaches the last loaded line and `Status == Ready`.
 - [ ] T046 [US1] Wire alt-screen entry/exit options in `cmd/spy/main.go`: `tea.WithAltScreen()`, `tea.WithMouseCellMotion()`, and a SIGWINCH-aware program option. Confirm `defer term.Restore()` still fires on panic.
+- [ ] T046b [P] [US1] Failing unit tests for ActionReload in `internal/ui/update_test.go` (covers spec.md edge case "What happens when a file is deleted or its permissions change while the viewer is open"): (a) successful reload re-invokes `loader.Open` on the current `Source` and replaces the buffer atomically; (b) reload after the underlying file is deleted retains the prior buffer and emits a status-bar error styled with `Theme.Error`; (c) reload while a previous stream is still draining cancels the previous `context.Context` first.
+- [ ] T046c [US1] Implement `ActionReload` handling in `internal/ui/update.go`: capture the active loader `cancel` func; on reload, call `cancel()`, then `loader.Open(ctx, m.Source, m.Config)` afresh; on success swap `m.Buffer` and clear `m.LastError`; on error keep `m.Buffer` and set `m.Status = StatusError` with the wrapped error in `m.LastError`. Bind `Ctrl-R` and `r` to `ActionReload` in `internal/keys/default.go` (verify T008's "every Action from contracts/keys.md must be present" still holds).
 
 **Checkpoint**: User Story 1 is fully functional. Steps 2 and 12 of
 `quickstart.md` pass. MVP is shippable here.
@@ -279,7 +284,7 @@ language is auto-detected (shebang, hint, Chroma `Analyse`).
 - [ ] T086 [P] [US5] Write failing tests for stdin language inference in `internal/source/detect_test.go`: shebang first line, `--lang` hint override, Chroma `Analyse` fallback, plain text when none match.
 - [ ] T087 [P] [US5] Write failing tests for `FromArgs` stdin construction in `internal/source/source_test.go`: TTY stdin + no file → `ErrNoInput`; non-TTY stdin + no file → `StdinSource`; `-` positional + TTY stdin → `StdinSource` (blocks per contract); both file and stdin → file wins.
 - [ ] T088 [P] [US5] Write a failing integration test in `tests/integration/stdin_test.go`: PTY pair, write a Go diff to stdin, assert highlighted-diff output and `<stdin>` in the footer.
-- [ ] T089 [P] [US5] Add failing E2E script `tests/e2e/05_pipe.sh`: `git diff HEAD~ | spy` (when run inside a git repo), `echo content | spy -`, and the degenerate-cat mode (`echo content | spy | cat`) which must exit 0 and pass content through verbatim with no escape sequences.
+- [ ] T089 [P] [US5] Add failing E2E script `tests/e2e/05_pipe.sh` exercising SC-011's three pipeline shapes: (a) `cat tests/fixtures/hello.go | spy -l go` (Go highlight, `<stdin>` footer); (b) `git diff HEAD~ | spy` when invoked inside the repo (diff highlight); (c) `grep -n needle tests/fixtures/hello.go | spy` (plain text, `<stdin>` footer). Plus the degenerate-cat path: `echo content | spy | cat` exits 0 and passes content through verbatim with no escape sequences.
 
 ### Implementation for User Story 5
 
@@ -326,8 +331,11 @@ and close residual constitution TODOs.
 
 - [ ] T101 [P] Refresh `README.md` to describe `spy` (not the placeholder text), with a quick install + usage section linking to `specs/001-popup-reader/contracts/cli.md`, `keys.md`, and `config.md`.
 - [ ] T102 [P] Update `DEVELOPMENT.md` with `make` target descriptions, the `-tags fitz` build instructions, and a brief on the `tests/integration` PTY harness.
-- [ ] T103 [P] Refresh the Constitution Check section in `specs/001-popup-reader/plan.md` to cite constitution v1.0.0 (closes `TODO(plan-001)` from `.specify/memory/constitution.md`).
+- [x] T103 [P] Refresh the Constitution Check section in `specs/001-popup-reader/plan.md` to cite constitution v1.0.0 (closes `TODO(plan-001)` from `.specify/memory/constitution.md`). *Done 2026-04-25 via speckit-analyze HIGH-fix C1.*
 - [ ] T104 [P] Add SC-001 benchmark in `tests/perf/firstframe_bench_test.go`: load a 100-line file end-to-end and assert ≤ 100 ms.
+- [ ] T104b [P] SC-002 scroll benchmark in `tests/perf/scroll_bench_test.go`: PTY-drive 100 sequential ScrollDown actions on `/tmp/spy-fixtures/big.txt` (10 000 lines); record per-frame wall-clock; assert p95 ≤ 16 ms (60 fps target) and zero dropped frames.
+- [ ] T104c [P] SC-004 theme-swap benchmark in `tests/perf/theme_swap_bench_test.go`: 100 `:set theme dark|light` swaps against a 10 000-line file; assert p95 re-render ≤ 16 ms and that the underlying token buffer is reused (no re-tokenization — verified via a counter on `Highlighter.Highlight` invocations).
+- [ ] T104d [P] SC-008 resize integration test in `tests/integration/resize_test.go`: drive 50 successive `tea.WindowSizeMsg` events at random widths in `[40, 200]` cols against a 10 000-line file; assert (a) the line previously at viewport row 0 remains at row 0, (b) the wrap cache is invalidated on each event, (c) p95 re-paint ≤ 16 ms.
 - [ ] T105 [P] Add SC-003 benchmark in `tests/perf/search_bench_test.go`: search across a 1 MiB synthetic file and assert ≤ 500 ms.
 - [ ] T106 [P] Add SC-005 benchmarks in `tests/perf/large_file_test.go` in **two tiers**:
       (a) `TestLargeFile_PRGate`: 200 MiB synthetic file (just above the 256 MiB windowed-mode threshold's complement — the largest file that *doesn't* trigger windowing), asserts RSS ≤ 250 MiB. Runs on every PR (no build tag); ~5s on commodity CI; gates the PR.

--- a/specs/001-popup-reader/tasks.md
+++ b/specs/001-popup-reader/tasks.md
@@ -15,6 +15,12 @@ NON-NEGOTIABLE. Every implementation task has a preceding failing-test task
 in the same logical change set. `go test ./... -race` and per-package
 coverage ≥ 80 % are gates on PR merge.
 
+**Test-sibling annotation**: Most implementation tasks have a preceding
+failing-test task in the same package. A small set of wiring/refactor
+tasks (T032, T035, T046, T065, T067) are covered by tests in adjacent
+packages and integration tests rather than dedicated unit tests; each is
+annotated below with `(test sibling: …)`.
+
 **Organization**: Tasks are grouped by user story (P1 → P3) so each story can
 be implemented, tested, and demoed independently after Foundational completes.
 
@@ -113,13 +119,13 @@ completes. Each task pair below puts the failing test first.
 
 - [ ] T030 [P] Write failing tests for flag parsing in `cmd/spy/flags_test.go` — every flag from `contracts/cli.md` (long + short forms), env var fallback, `--help` / `--version` exits, `--config` vs `--no-config` mutual exclusion, unknown flag → exit 2.
 - [ ] T031 Extract flag definitions into `cmd/spy/flags.go` exposing `ParseFlags([]string) (*ParsedFlags, error)`; pure (no side effects) so it's testable.
-- [ ] T032 Replace `cmd/spy/main.go` with the foundational wiring: `term.Detect` → `config.Load` → `source.FromArgs` → `loader.Open` → `ui.NewModel` → `tea.NewProgram(model, tea.WithAltScreen()).Run()`. Implement FR-013 stderr error path with the documented exit codes (0/1/2/3/4/5/130/143) and the `spy: <reason>: <detail>` format from `contracts/cli.md`. Defer order (LIFO, panic-safe per research R10): `defer restore := term.Restore()` first, then `defer graphics.CleanupFunc(caps.Graphics)()` second so graphics cleanup runs *before* terminal restore. The graphics-cleanup defer is a no-op until US4 lands but the wiring is added here so panic-safety is correct from the foundational phase.
+- [ ] T032 (test sibling: T030 flag tests + T035b signal test + integration tests T040, T088) Replace `cmd/spy/main.go` with the foundational wiring: `term.Detect` → `config.Load` → `source.FromArgs` → `loader.Open` → `ui.NewModel` → `tea.NewProgram(model, tea.WithAltScreen()).Run()`. Implement FR-013 stderr error path with the documented exit codes (0/1/2/3/4/5/130/143) and the `spy: <reason>: <detail>` format from `contracts/cli.md`. Defer order (LIFO, panic-safe per research R10): capture `restore := term.Restore()` then `defer restore()`; capture `cleanupGraphics := graphics.CleanupFunc(caps.Graphics)` then `defer cleanupGraphics()`. LIFO ordering means `cleanupGraphics()` runs first (graphics cleanup before terminal restore), then `restore()` runs last. The graphics-cleanup defer is a no-op until US4 lands but the wiring is added here so panic-safety is correct from the foundational phase.
 
 ### `internal/ui` rewiring
 
 - [ ] T033 [P] Write failing tests for `NewModel`, `Init`, `Update` (handles `tea.WindowSizeMsg`, `chunkLoadedMsg`, key events), and `View` in `internal/ui/model_test.go`. Cover: foundational quit on `q`/Esc/Ctrl-C, scroll up/down with arrow keys, end-of-file indicator on last line, resize reflows viewport.
 - [ ] T034 Replace `internal/ui/model.go` with a `bubbles/viewport`-based `Model`, `NewModel(opts ModelOptions) Model`, `ModelOptions` matching `contracts/internal-apis.md`, and the foundational `Init`/`Update`/`View`. Wire the `internal/keys.Default()` keymap; vim mode is added in US2.
-- [ ] T035 [P] Split UI into `internal/ui/update.go`, `internal/ui/view.go`, `internal/ui/help.go` (help is a stub overlay until later stories add bindings to surface).
+- [ ] T035 [P] (test sibling: T033 — refactor only, behavior unchanged) Split UI into `internal/ui/update.go`, `internal/ui/view.go`, `internal/ui/help.go` (help is a stub overlay until later stories add bindings to surface).
 - [ ] T035b [P] Failing integration test in `tests/integration/signal_test.go` driving the PTY harness against `/tmp/spy-fixtures/big.txt` (covers FR-015 / SC-008 signal-handling gate that Constitution Principle II requires): once the alt-screen frame is observed, send SIGINT and assert (a) process exits with code 130 within 1 s, (b) terminal modes restored (echo on, cursor visible, alt-screen exited via the `\x1b[?1049l` sequence), (c) no residual escape sequences trail on stdout. Repeat the run sending SIGTERM and assert exit code 143. Graphics-cleanup assertions deferred to T083; this task only covers the foundational `defer term.Restore()` chain from T032.
 
 ### Cleanup of legacy skeleton
@@ -158,7 +164,7 @@ the matching golden-file integration test.
       (a) feed loader chunks through `Highlighter.HighlightStream` when `source.Kind == KindCode`,
       (b) trigger a re-render frame on `chunkLoadedMsg` so highlighted content appears progressively,
       (c) display "END" indicator (`render.Theme.Footer`) when the viewport reaches the last loaded line and `Status == Ready`.
-- [ ] T046 [US1] Wire alt-screen entry/exit options in `cmd/spy/main.go`: `tea.WithAltScreen()`, `tea.WithMouseCellMotion()`, and a SIGWINCH-aware program option. Confirm `defer term.Restore()` still fires on panic.
+- [ ] T046 [US1] (test sibling: T040 PTY integration test) Wire alt-screen entry/exit options in `cmd/spy/main.go`: `tea.WithAltScreen()`, `tea.WithMouseCellMotion()`, and a SIGWINCH-aware program option. Confirm `defer term.Restore()` still fires on panic.
 - [ ] T046b [P] [US1] Failing unit tests for ActionReload in `internal/ui/update_test.go` (covers spec.md edge case "What happens when a file is deleted or its permissions change while the viewer is open"): (a) successful reload re-invokes `loader.Open` on the current `Source` and replaces the buffer atomically; (b) reload after the underlying file is deleted retains the prior buffer and emits a status-bar error styled with `Theme.Error`; (c) reload while a previous stream is still draining cancels the previous `context.Context` first.
 - [ ] T046c [US1] Implement `ActionReload` handling in `internal/ui/update.go`: capture the active loader `cancel` func; on reload, call `cancel()`, then `loader.Open(ctx, m.Source, m.Config)` afresh; on success swap `m.Buffer` and clear `m.LastError`; on error keep `m.Buffer` and set `m.Status = StatusError` with the wrapped error in `m.LastError`. Bind `Ctrl-R` and `r` to `ActionReload` in `internal/keys/default.go` (verify T008's "every Action from contracts/keys.md must be present" still holds).
 
@@ -219,9 +225,9 @@ light` at runtime visibly switches.
 ### Implementation for User Story 3
 
 - [ ] T064 [US3] Implement OSC 11 luminance probe via `muesli/termenv`'s `BackgroundColor()` in `internal/term/theme.go`, with a 50 ms total timeout and `COLORFGBG` env-var fallback.
-- [ ] T065 [US3] Wire `BackgroundLuminance` into `term.Detect()` (replacing the `NaN` placeholder from T012). Honour `SPY_THEME` to short-circuit the probe entirely.
+- [ ] T065 [US3] (test sibling: T060 OSC probe + T011 Detect tests) Wire `BackgroundLuminance` into `term.Detect()` (replacing the `NaN` placeholder from T012). Honour `SPY_THEME` to short-circuit the probe entirely.
 - [ ] T066 [US3] Replace the placeholder `ResolveTheme` from T029 with the full implementation in `internal/render/theme.go`: respects `cfg.Theme` (`auto`/`dark`/`light`/named Chroma style), `caps.BackgroundLuminance`, and `cfg.NoColor` (forces a Mono theme that disables Chroma styling).
-- [ ] T067 [US3] Wire runtime theme swap (`:set theme …` from T058) to `ResolveTheme` and re-render in `internal/ui/update.go`; the in-memory token buffer is reused — only the formatter changes.
+- [ ] T067 [US3] (test sibling: T061 ResolveTheme + T062 integration) Wire runtime theme swap (`:set theme …` from T058) to `ResolveTheme` and re-render in `internal/ui/update.go`; the in-memory token buffer is reused — only the formatter changes.
 
 **Checkpoint**: User Story 3 is functional. Steps 6 and 15 of `quickstart.md`
 pass. P1 stories (US1, US2, US3) all green.
@@ -259,9 +265,9 @@ graphics-capable terminal *and* one non-graphics terminal.
 - [ ] T081 [US4] Replace the `KindPDF` stub in `internal/render/pdf.go`: pdfcpu page-text extraction by default; on graphics-capable terminals AND `fitz` build, rasterize the current page and render via `graphics.Render`. Track `Page` index in the renderer state.
 - [ ] T082 [US4] Wire `]` / `[` page navigation when `source.Kind == KindPDF` and `:N` for page-jump (re-using the command-line state from T056) in `internal/ui/update.go`.
 - [ ] T083 [US4] Wire panic-safe graphics cleanup in **two** places (per `research.md` R10):
-      (a) `cmd/spy/main.go`: after capability detection, capture `cleanupGraphics := graphics.CleanupFunc(caps.Graphics)` and `defer cleanupGraphics()` *inside* the existing `defer term.Restore()` chain (LIFO ordering: graphics cleanup runs first, then terminal restore). This fires on `tea.Quit`, signals, AND panic — including cgo `go-fitz` panics that skip Bubble Tea's normal teardown.
+      (a) `cmd/spy/main.go`: T032 already wires `defer cleanupGraphics()` after `defer restore()` with a no-op closure. With US4's `graphics.CleanupFunc` now real (returning a closure that writes the protocol's "delete all images" escape — load-bearing for Kitty, no-op for Sixel/iTerm2/None), T032's wiring becomes load-bearing without any code change at this site. Verify via an integration test that the Kitty cleanup escape is emitted on `tea.Quit`, on SIGINT, AND on panic — including a synthetic cgo `go-fitz` panic — by extending T035b's harness with a graphics-emit assertion.
       (b) `internal/ui/update.go`: on source replacement (`:open`), invoke `graphics.Cleanup(caps.Graphics)` via a `tea.Cmd` so the previous source's images are cleared before the new ones render. The cleanup func must be idempotent.
-      Add a `graphics.CleanupFunc(proto term.Graphics) func()` constructor in `internal/graphics/graphics.go` returning a closure that writes the appropriate escape sequence to `os.Stdout` (no-op for `GraphicsNone`, `GraphicsITerm2`, `GraphicsSixel`).
+      Add a `graphics.CleanupFunc(proto term.Graphics) func()` constructor in `internal/graphics/graphics.go` (the no-op stub created in T032 is replaced here) returning a closure that writes the appropriate escape sequence to `os.Stdout`.
 - [ ] T084 [US4] Honour `--graphics` flag and `SPY_GRAPHICS` env via the merge order from T024 (CLI > env > config > auto-detect). `--graphics none` short-circuits all encoding.
 
 **Checkpoint**: User Story 4 is functional. Steps 7 and 8 of `quickstart.md`
@@ -280,7 +286,7 @@ language is auto-detected (shebang, hint, Chroma `Analyse`).
 
 ### Tests for User Story 5 ⚠️
 
-- [ ] T085 [P] [US5] Write failing tests for `StdinSource` in `internal/source/stdin_test.go`: `Open()` returns the underlying reader, `Reopen()` returns `nil, ErrNotSeekable`, `DisplayName()` is `<stdin>`.
+- [ ] T085 [P] [US5] Write failing tests for `StdinSource` in `internal/source/stdin_test.go`: first `Open()` returns the underlying reader, second `Open()` returns `nil, ErrAlreadyConsumed`, `Reopen()` returns `nil, ErrNotSeekable`, `DisplayName()` is `<stdin>`.
 - [ ] T086 [P] [US5] Write failing tests for stdin language inference in `internal/source/detect_test.go`: shebang first line, `--lang` hint override, Chroma `Analyse` fallback, plain text when none match.
 - [ ] T087 [P] [US5] Write failing tests for `FromArgs` stdin construction in `internal/source/source_test.go`: TTY stdin + no file → `ErrNoInput`; non-TTY stdin + no file → `StdinSource`; `-` positional + TTY stdin → `StdinSource` (blocks per contract); both file and stdin → file wins.
 - [ ] T088 [P] [US5] Write a failing integration test in `tests/integration/stdin_test.go`: PTY pair, write a Go diff to stdin, assert highlighted-diff output and `<stdin>` in the footer.
@@ -318,6 +324,11 @@ updates on scroll/resize, collapses gracefully under 80 columns.
 - [ ] T098 [US6] Implement `statusbar.Render(meta source.Metadata, vp viewport.Model, theme Theme) string` in `internal/render/statusbar.go`. Use `lipgloss` styles from the active `Theme`. Below 80 cols, emit only `<short-name> · L<current>`.
 - [ ] T099 [US6] Wire the statusbar into `internal/ui/View` in `internal/ui/view.go` so it renders on every frame; subscribe to `tea.WindowSizeMsg` for width updates.
 - [ ] T100 [US6] Update `loader.Stream` to surface `LineCount` updates (post a `metaUpdatedMsg{TotalLines int64}` on EOF) so the footer can switch from `…` to the final count without re-rendering everything.
+- [ ] T100b [P] [US6] Failing tests in `internal/ui/update_test.go` for `ActionToggleLineNumbers`, `ActionToggleWordWrap`, and `ActionOpenFile`: each toggle flips the corresponding `Config` field, triggers a render frame, and (for word-wrap) invalidates `Line.Wrapped` caches across the loaded buffer. `ActionOpenFile` opens the command-line prompt with `Buffer = "open "` and `CommandLineState.Active = true`, focused for the user to type the path.
+- [ ] T100c [US6] Implement the three handlers in `internal/ui/update.go`:
+      - `ActionToggleLineNumbers` flips `m.Config.LineNumbers`; the next render frame re-reads the field.
+      - `ActionToggleWordWrap` flips `m.Config.WordWrap`, walks the loaded buffer to set each `Line.Wrapped = nil`, and triggers a re-render so `internal/render/code.go` re-wraps from scratch at the active width.
+      - `ActionOpenFile` opens the command-line prompt pre-populated with `open ` (reuses the `:open` handler from T058); on Esc the prompt closes without reloading.
 
 **Checkpoint**: All P1/P2/P3 stories functional. `quickstart.md` Steps 1–15
 all pass on a Linux + xterm-compatible terminal.
@@ -338,15 +349,16 @@ and close residual constitution TODOs.
 - [ ] T104d [P] SC-008 resize integration test in `tests/integration/resize_test.go`: drive 50 successive `tea.WindowSizeMsg` events at random widths in `[40, 200]` cols against a 10 000-line file; assert (a) the line previously at viewport row 0 remains at row 0, (b) the wrap cache is invalidated on each event, (c) p95 re-paint ≤ 16 ms.
 - [ ] T105 [P] Add SC-003 benchmark in `tests/perf/search_bench_test.go`: search across a 1 MiB synthetic file and assert ≤ 500 ms.
 - [ ] T106 [P] Add SC-005 benchmarks in `tests/perf/large_file_test.go` in **two tiers**:
-      (a) `TestLargeFile_PRGate`: 200 MiB synthetic file (just above the 256 MiB windowed-mode threshold's complement — the largest file that *doesn't* trigger windowing), asserts RSS ≤ 250 MiB. Runs on every PR (no build tag); ~5s on commodity CI; gates the PR.
+      (a) `TestLargeFile_PRGate`: 200 MiB synthetic file (just below the 256 MiB windowed-mode threshold — the largest size that does NOT trigger windowing), asserts RSS ≤ 250 MiB. Runs on every PR (no build tag); ~5s on commodity CI; gates the PR.
       (b) `TestLargeFile_Nightly`: 1 GiB synthetic file, asserts RSS ≤ 500 MiB. Behind `-tags perf`; CI runs it on a nightly schedule via `.github/workflows/nightly-perf.yml` against an `ubuntu-latest` runner with `RUNNER_OS_RAM_HINT=8192`. A failure files an issue tagged `perf-regression` rather than blocking PRs (because the nightly cadence makes blame attribution clear).
       The PR-gate version catches algorithmic regressions; the nightly catches scaling-only regressions. SC-005's 1 GiB / 500 MiB promise is owned by (b).
 - [ ] T106a [P] Add SC-006 corpus + check in `tests/perf/highlight_corpus_test.go`: 50 source files under `tests/fixtures/highlight-corpus/` (one per GitHub Linguist top-50 language by repo count, each ≤ 4 KiB representative sample); assert Chroma selects a non-`fallback` lexer and ≤ 1 % of bytes per file land in `chroma.Error` tokens. Pass threshold: 47/50.
 - [ ] T106b [P] Add SC-007 dismiss benchmark in `tests/perf/dismiss_bench_test.go`: drive the PTY harness against `big.txt` 100 times, send `q`, measure wall-clock from keypress to `tea.Program.Run()` return; assert p95 ≤ 500 ms.
 - [ ] T106c [P] Add `.github/workflows/nightly-perf.yml`: scheduled `cron: '0 8 * * *'`, runs `make perf` (`go test -tags perf ./tests/perf/...`), uploads benchmark output as an artifact, opens an issue tagged `perf-regression` on failure (`peter-evans/create-issue-from-file@v5` or equivalent). Also add `make perf` target to `Makefile` (T003 add-on).
 - [ ] T107 [P] Run `reuse lint` and add SPDX headers to any files added across all phases that missed them. CI hook from T003 must pass.
-- [ ] T108 [P] Manual quickstart.md walkthrough on Linux/xterm; record results in `specs/001-popup-reader/checklists/quickstart-validation.md`.
-- [ ] T109 [P] Manual quickstart.md walkthrough on macOS/iTerm2 + Kitty; same checklist.
+- [ ] T108 [P] Implementer's quickstart.md walkthrough on Linux/xterm; record under `## Reviewer 1 (implementer)` in `specs/001-popup-reader/checklists/quickstart-validation.md`.
+- [ ] T109 [P] Implementer's quickstart.md walkthrough on macOS/iTerm2 + Kitty; record under `## Reviewer 1 (implementer, additional terminal)` in the same checklist.
+- [ ] T109a Recruit 2 independent reviewers (NOT the implementer) and have each complete `quickstart.md` Steps 2, 4, and 12 using only `F1`/`?`; record pass/fail per SC-012 under `## Reviewer 2` and `## Reviewer 3`. Block the v0.1.0 tag (T111) until both reviewers pass.
 - [ ] T109b Security review pass before tag. Cover, at minimum:
       (a) **Path handling**: file argument is `filepath.Clean`'ed; symlink target is checked for traversal outside `$HOME` only when `--debug` warns about it (we follow symlinks per `contracts/cli.md`, but don't open files whose canonicalized path is on a denylist of pseudo-fs roots: `/proc/self/mem`, `/dev/zero`, `/dev/random`, `/sys`).
       (b) **TOML parser robustness**: fuzz `config.Load` with `go test -fuzz=FuzzConfigLoad ./internal/config/...` for ≥ 60 s; corpus seeded from `examples/config.toml` plus malformed cases (deeply nested tables, huge integers, invalid UTF-8 in strings). Failures must surface as warnings (per T024/T025 contract) — never crash.

--- a/specs/001-popup-reader/tasks.md
+++ b/specs/001-popup-reader/tasks.md
@@ -44,7 +44,7 @@ compile, run tests with `-race`, and meet REUSE/SPDX requirements.
 
 - [ ] T001 Add new dependencies to `go.mod` and `go.sum`: `github.com/charmbracelet/bubbles`, `github.com/BurntSushi/toml`, `github.com/mattn/go-sixel`, `github.com/gen2brain/go-fitz`, `github.com/muesli/termenv`, `golang.org/x/term`. Run `go mod tidy` and verify pure-Go default build still compiles without `-tags fitz`.
 - [ ] T002 [P] Create new package skeleton directories with SPDX-headed `doc.go` for each: `internal/term/doc.go`, `internal/source/doc.go`, `internal/loader/doc.go`, `internal/highlight/doc.go`, `internal/graphics/doc.go`, `internal/render/doc.go`, `internal/search/doc.go`, `internal/keys/doc.go`. Each `doc.go` carries the dual-license SPDX header and a one-paragraph package summary.
-- [ ] T003 [P] Update `Makefile` with targets: `test` (`go test ./...`), `test-race` (`go test ./... -race`), `cover` (`go test ./... -race -coverprofile=coverage.out`), `lint` (`gofmt -l . && goimports -l .`), `vet` (`go vet ./...`), `build` (default), `build-fitz` (`-tags fitz`), `reuse` (`reuse lint`).
+- [ ] T003 [P] Update `Makefile` with targets: `test` (`go test ./...`), `test-race` (`go test ./... -race`), `cover-default` (`go test ./... -race -coverprofile=cov-default.out`), `cover-fitz` (`go test -tags fitz ./... -race -coverprofile=cov-fitz.out`), `cover` (depends on `cover-default` and `cover-fitz`; merges via `gocovmerge cov-default.out cov-fitz.out > coverage.out`), `lint` (`gofmt -l . && goimports -l .`), `vet` (`go vet ./...` and `go vet -tags fitz ./...`), `build` (default), `build-fitz` (`-tags fitz`), `reuse` (`reuse lint`). The merged `coverage.out` is the single source of truth for the ≥ 80 %/package gate so neither `pdf_fitz.go` nor `pdf_nofitz.go` is invisible to the threshold check. Add `gocovmerge` (or equivalent) to dev-tooling install instructions in `DEVELOPMENT.md` (T102).
 - [ ] T004 [P] Create PTY harness skeleton in `tests/integration/pty.go` and `tests/integration/helpers.go` exposing `NewPTYProgram(t, args, env)` and golden-file diffing helpers; mark with SPDX header.
 - [ ] T005 [P] Create `tests/e2e/` directory with `tests/e2e/run.sh` shell harness that builds the binary and runs each `tests/e2e/NN_*.sh` script, plus `tests/e2e/fixtures/` and a `tests/e2e/setup.sh` that materializes `quickstart.md` Section 0 fixtures locally.
 - [ ] T006 [P] Author `examples/config.toml` matching the schema in `specs/001-popup-reader/contracts/config.md`, with all keys commented out at their default values plus three commented sample profiles (`theme = "dark"`; vim+regex+tight memory; per-language overrides).
@@ -111,7 +111,7 @@ completes. Each task pair below puts the failing test first.
 
 - [ ] T030 [P] Write failing tests for flag parsing in `cmd/spy/flags_test.go` — every flag from `contracts/cli.md` (long + short forms), env var fallback, `--help` / `--version` exits, `--config` vs `--no-config` mutual exclusion, unknown flag → exit 2.
 - [ ] T031 Extract flag definitions into `cmd/spy/flags.go` exposing `ParseFlags([]string) (*ParsedFlags, error)`; pure (no side effects) so it's testable.
-- [ ] T032 Replace `cmd/spy/main.go` with the foundational wiring: `term.Detect` → `config.Load` → `source.FromArgs` → `loader.Open` → `ui.NewModel` → `tea.NewProgram(model, tea.WithAltScreen()).Run()`. Implement FR-013 stderr error path with the documented exit codes (0/1/2/3/4/5/130/143) and the `spy: <reason>: <detail>` format from `contracts/cli.md`. `defer term.Restore()` belt-and-suspenders.
+- [ ] T032 Replace `cmd/spy/main.go` with the foundational wiring: `term.Detect` → `config.Load` → `source.FromArgs` → `loader.Open` → `ui.NewModel` → `tea.NewProgram(model, tea.WithAltScreen()).Run()`. Implement FR-013 stderr error path with the documented exit codes (0/1/2/3/4/5/130/143) and the `spy: <reason>: <detail>` format from `contracts/cli.md`. Defer order (LIFO, panic-safe per research R10): `defer restore := term.Restore()` first, then `defer graphics.CleanupFunc(caps.Graphics)()` second so graphics cleanup runs *before* terminal restore. The graphics-cleanup defer is a no-op until US4 lands but the wiring is added here so panic-safety is correct from the foundational phase.
 
 ### `internal/ui` rewiring
 
@@ -252,7 +252,10 @@ graphics-capable terminal *and* one non-graphics terminal.
 - [ ] T080 [US4] Replace the `KindImage` stub in `internal/render/image.go`: capable terminals → `graphics.Render`; otherwise the metadata fallback block. Re-open the file at render time (per `research.md` R2) to keep memory under SC-005.
 - [ ] T081 [US4] Replace the `KindPDF` stub in `internal/render/pdf.go`: pdfcpu page-text extraction by default; on graphics-capable terminals AND `fitz` build, rasterize the current page and render via `graphics.Render`. Track `Page` index in the renderer state.
 - [ ] T082 [US4] Wire `]` / `[` page navigation when `source.Kind == KindPDF` and `:N` for page-jump (re-using the command-line state from T056) in `internal/ui/update.go`.
-- [ ] T083 [US4] Wire Kitty "delete all images" cleanup on `tea.Quit` and on source replacement (`:open`) in `internal/ui/update.go` — call `graphics.Cleanup(caps.Graphics)` and write its output via a `tea.Cmd` before the model exits.
+- [ ] T083 [US4] Wire panic-safe graphics cleanup in **two** places (per `research.md` R10):
+      (a) `cmd/spy/main.go`: after capability detection, capture `cleanupGraphics := graphics.CleanupFunc(caps.Graphics)` and `defer cleanupGraphics()` *inside* the existing `defer term.Restore()` chain (LIFO ordering: graphics cleanup runs first, then terminal restore). This fires on `tea.Quit`, signals, AND panic — including cgo `go-fitz` panics that skip Bubble Tea's normal teardown.
+      (b) `internal/ui/update.go`: on source replacement (`:open`), invoke `graphics.Cleanup(caps.Graphics)` via a `tea.Cmd` so the previous source's images are cleared before the new ones render. The cleanup func must be idempotent.
+      Add a `graphics.CleanupFunc(proto term.Graphics) func()` constructor in `internal/graphics/graphics.go` returning a closure that writes the appropriate escape sequence to `os.Stdout` (no-op for `GraphicsNone`, `GraphicsITerm2`, `GraphicsSixel`).
 - [ ] T084 [US4] Honour `--graphics` flag and `SPY_GRAPHICS` env via the merge order from T024 (CLI > env > config > auto-detect). `--graphics none` short-circuits all encoding.
 
 **Checkpoint**: User Story 4 is functional. Steps 7 and 8 of `quickstart.md`
@@ -330,7 +333,7 @@ and close residual constitution TODOs.
 - [ ] T108 [P] Manual quickstart.md walkthrough on Linux/xterm; record results in `specs/001-popup-reader/checklists/quickstart-validation.md`.
 - [ ] T109 [P] Manual quickstart.md walkthrough on macOS/iTerm2 + Kitty; same checklist.
 - [ ] T110 Add a `CHANGELOG.md` `0.1.0` entry summarizing US1–US6.
-- [ ] T111 Final gate: `make lint vet test-race cover` clean, per-package coverage ≥ 80 %, `reuse lint` clean, default and `-tags fitz` builds both succeed.
+- [ ] T111 Final gate: `make lint vet test-race cover` clean, per-package coverage ≥ 80 % computed against the **merged** profile from `cover-default` + `cover-fitz` (so build-tag-gated files in `internal/graphics` are not silently excluded), `reuse lint` clean, default and `-tags fitz` builds both succeed.
 
 ---
 

--- a/specs/001-popup-reader/tasks.md
+++ b/specs/001-popup-reader/tasks.md
@@ -140,7 +140,7 @@ the matching golden-file integration test.
 
 ### Tests for User Story 1 ⚠️ (write first, FAIL before implementation)
 
-- [ ] T037 [P] [US1] Write failing tests for `Highlighter` in `internal/highlight/highlighter_test.go`: lexer auto-selection by language hint, fallback to plain text on unknown lexer, `HighlightCap` short-circuit (returns `Token{Type: Text}` for the whole line above the cap), streaming behaviour over a chunk channel.
+- [ ] T037 [P] [US1] Write failing tests for `Highlighter` in `internal/highlight/highlighter_test.go`: lexer auto-selection by language hint, fallback to plain text on unknown lexer, `HighlightCap` short-circuit (returns `Token{Type: Text}` for the whole line above the cap) **AND emits `WarnHighlightDisabled` exactly once per session on the side channel**, streaming behaviour over a chunk channel, `SetCap` adjusts the cap mid-session.
 - [ ] T038 [P] [US1] Write failing tests for the `KindCode` renderer in `internal/render/code_test.go`: ANSI output matches a golden file under `tests/integration/golden/hello_go_dark.txt`, line-number column rendering, `--no-line-numbers` honoured, soft-wrap behaviour.
 - [ ] T039 [P] [US1] Write failing tests for the `KindMarkdown` renderer in `internal/render/markdown_test.go`: Glamour rendering of headings/lists/code blocks against a golden file under `tests/integration/golden/sample_md.txt`.
 - [ ] T040 [P] [US1] Write a failing integration test in `tests/integration/text_review_test.go` driving the PTY harness against a small Go file: assert highlighted output, scroll-down behaviour, `q` exit.
@@ -148,7 +148,7 @@ the matching golden-file integration test.
 
 ### Implementation for User Story 1
 
-- [ ] T042 [US1] Implement `Highlighter`, `New(theme, depth, capBytes)`, `Highlight(lang, line)`, and `HighlightStream(ctx, in, out)` in `internal/highlight/highlighter.go` using `chroma/v2` lexers + `formatters.TTY256`/`TrueColour` selected from `term.ColorDepth`. Honour `HighlightCap` from config (above-cap → no-op).
+- [ ] T042 [US1] Implement `Highlighter`, `New(theme, depth, capBytes)`, `Highlight(lang, line)`, and `HighlightStream(ctx, in, out)` in `internal/highlight/highlighter.go` using `chroma/v2` lexers + `formatters.TTY256`/`TrueColour` selected from `term.ColorDepth`. Honour `HighlightCap` from config: above-cap, `Highlight*` return tokens of type `chroma.Text` (effective no-op styling) AND emit a one-shot `WarnHighlightDisabled{Cap int64}` message on a side channel that `internal/ui` surfaces in the status bar (per research R7 — "downgrade is surfaced, not silent"). The warning auto-clears after 5 s or on next status update. Add `Highlighter.SetCap(int64)` so `:set highlight_cap …` (future) can adjust at runtime; for v0.1.0 the runtime command is not exposed but the API is.
 - [ ] T043 [US1] Replace the `KindCode` stub with the real renderer in `internal/render/code.go`: consumes `[]source.Token` from the highlighter (or raw `Line.Raw` when `Tokens == nil`), formats with `lipgloss.Style` for line numbers, soft-wraps at viewport width when `Config.WordWrap` is true.
 - [ ] T044 [US1] Replace the `KindMarkdown` stub with a Glamour-backed renderer in `internal/render/markdown.go`. Pick the Glamour style from the active `Theme` (dark → `dark`, light → `light`). Disable Glamour when stdout color depth is `Mono`.
 - [ ] T045 [US1] Update `internal/ui/Model.Update` in `internal/ui/update.go` to:
@@ -206,7 +206,7 @@ light` at runtime visibly switches.
 
 ### Tests for User Story 3 ⚠️
 
-- [ ] T060 [P] [US3] Write failing tests for OSC 11 query + `COLORFGBG` fallback in `internal/term/theme_test.go` (mock the response stream; assert luminance ≥ 0.5 → light, < 0.5 → dark, malformed → NaN, timeout → NaN).
+- [ ] T060 [P] [US3] Write failing tests for OSC 11 query + `COLORFGBG` fallback in `internal/term/theme_test.go`. Mock the response stream and cover: well-formed `rgb:RRRR/GGGG/BBBB` (luminance ≥ 0.5 → light, < 0.5 → dark), well-formed with `\x1b\\` ST terminator instead of `\x07` BEL, malformed → NaN, timeout → NaN. **Adversarial fixtures (per research R6 defensive parsing)**: oversize reply (>64 B), CSI-embedded reply (e.g., `\x1b]11;rgb:\x1b[2J/0/0\x07` — must reject without ever echoing the embedded CSI), mid-stream abort (partial bytes then EOF), reply with extra trailing bytes. Each adversarial case asserts: (a) returns NaN, (b) discarded bytes do not appear on stdout, (c) no panic. The probe must also be bypassed when `NO_COLOR=1`, `SPY_THEME=…`, or stdout is non-TTY — three additional cases.
 - [ ] T061 [P] [US3] Write failing tests for `ResolveTheme(cfg, caps)` in `internal/render/theme_test.go`: `auto` + light caps → light theme; `auto` + dark caps → dark theme; `auto` + NaN luminance → dark fallback; explicit `light`/`dark`/`<chroma-style>` always wins.
 - [ ] T062 [P] [US3] Write a failing integration test in `tests/integration/theme_test.go` using a fake PTY that replies to OSC 11 with a light-grey colour, asserting the rendered ANSI uses the `github` Chroma style.
 - [ ] T063 [P] [US3] Add failing E2E script `tests/e2e/03_theme.sh` covering `--theme dark`, `--theme light`, `SPY_THEME=light`, `NO_COLOR=1` (forces mono).
@@ -339,8 +339,16 @@ and close residual constitution TODOs.
 - [ ] T107 [P] Run `reuse lint` and add SPDX headers to any files added across all phases that missed them. CI hook from T003 must pass.
 - [ ] T108 [P] Manual quickstart.md walkthrough on Linux/xterm; record results in `specs/001-popup-reader/checklists/quickstart-validation.md`.
 - [ ] T109 [P] Manual quickstart.md walkthrough on macOS/iTerm2 + Kitty; same checklist.
+- [ ] T109b Security review pass before tag. Cover, at minimum:
+      (a) **Path handling**: file argument is `filepath.Clean`'ed; symlink target is checked for traversal outside `$HOME` only when `--debug` warns about it (we follow symlinks per `contracts/cli.md`, but don't open files whose canonicalized path is on a denylist of pseudo-fs roots: `/proc/self/mem`, `/dev/zero`, `/dev/random`, `/sys`).
+      (b) **TOML parser robustness**: fuzz `config.Load` with `go test -fuzz=FuzzConfigLoad ./internal/config/...` for ≥ 60 s; corpus seeded from `examples/config.toml` plus malformed cases (deeply nested tables, huge integers, invalid UTF-8 in strings). Failures must surface as warnings (per T024/T025 contract) — never crash.
+      (c) **Terminal escape injection from file content**: `internal/render/code.go` MUST strip or neutralize `\x1b` bytes in input before they reach stdout when ANSI styling is active. Test: a file containing `\x1b]2;malicious\x07` (window-title set) must not change the user's terminal title. Add `tests/integration/escape_injection_test.go`.
+      (d) **OSC response parsing**: `term.theme` MUST validate the OSC 11 reply against a strict regex (`^\x1b\]11;rgb:[0-9a-fA-F/]+\x07$`) and discard anything else. Test with adversarial replies that embed CSI sequences. (Cross-ref MEDIUM #16.)
+      (e) **Graphics protocol input safety**: image / PDF source bytes are never executed; the `image` and `go-fitz` decoders are the trust boundary. Decoder panics are recovered in `internal/graphics/{kitty,iterm2,sixel}.go` and surfaced as `ErrUnsupported`.
+      (f) **No accidental network**: `grep -rE "(http\.|https://|net\.Dial|Get\()" internal/ cmd/` returns no matches (verified by a CI grep gate).
+      Document findings in `specs/001-popup-reader/checklists/security-review.md`; CRITICAL/HIGH issues block the v0.1.0 tag.
 - [ ] T110 Add a `CHANGELOG.md` `0.1.0` entry summarizing US1–US6.
-- [ ] T111 Final gate: `make lint vet test-race cover` clean, per-package coverage ≥ 80 % computed against the **merged** profile from `cover-default` + `cover-fitz` (so build-tag-gated files in `internal/graphics` are not silently excluded), `reuse lint` clean, default and `-tags fitz` builds both succeed.
+- [ ] T111 Final gate: `make lint vet test-race cover` clean, per-package coverage ≥ 80 % computed against the **merged** profile from `cover-default` + `cover-fitz` (so build-tag-gated files in `internal/graphics` are not silently excluded), `reuse lint` clean, default and `-tags fitz` builds both succeed, **T109b security review checklist signed off**.
 
 ---
 


### PR DESCRIPTION
Capture spec.md (clarified), plan.md, research.md, data-model.md,
quickstart.md, and contracts/ for the popup reader feature. Update
CLAUDE.md SPECKIT marker to reference the new plan.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>