### PR TITLE
fix(spec-001): close acceptance-review C7 — consume Stream.Errs in production UI

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -208,6 +208,22 @@ type streamDoneMsg struct {
 	stream *loader.Stream
 }
 
+// streamErrMsg announces a warning or error read from
+// [loader.Stream.Errs] — the side-channel the loader uses to surface
+// non-fatal conditions like [loader.ErrLineTruncated] (a single line
+// exceeded MaxLineBytes and was clipped) or [loader.ErrStdinNonSeekable]
+// (windowed-mode entered against non-seekable stdin so scroll-back is
+// unavailable past the resident region).
+//
+// The originating Stream is carried so post-reload deliveries from
+// the previous loader don't surface against the new session's source
+// (acceptance review C7 — `Stream.Errs` was unconsumed in production
+// before this message landed).
+type streamErrMsg struct {
+	err    error
+	stream *loader.Stream
+}
+
 // reloadMsg requests a fresh loader.Open against the current Source.
 // Fired by the keymap's ActionReload binding.
 type reloadMsg struct{}

--- a/internal/ui/stream_errs_test.go
+++ b/internal/ui/stream_errs_test.go
@@ -133,9 +133,11 @@ func TestC7_FormatStreamErr_Sentinels(t *testing.T) {
 	}
 }
 
-// TestC7_Init_SubscribesToErrsChannel proves the Init pipeline
-// includes waitForStreamErr — without it, a real warning emitted
-// by the loader's truncation path would never reach a subscriber.
+// TestC7_WaitForStreamErr_DeliversTaggedMsg proves waitForStreamErr
+// subscribes to [loader.Stream.Errs] and tags the delivered warning
+// with the originating stream — the contract that lets the
+// stale-stream guard in [Model.onStreamErr] discriminate warnings
+// from a swapped-out reload/`:open` stream.
 //
 // The test drives a synthetic stream whose Errs channel has a
 // pre-injected warning, calls waitForStreamErr directly, and
@@ -144,9 +146,10 @@ func TestC7_FormatStreamErr_Sentinels(t *testing.T) {
 //
 // We don't drive Init() end-to-end here — that returns a tea.Batch
 // whose order is implementation-detail and whose subordinate cmds
-// can block on an empty Errs channel. The contract that matters is
-// "subscribed AND tagged correctly", which waitForStreamErr fully
-// expresses.
+// can block on an empty Errs channel. The "subscribed AND tagged
+// correctly" contract is what waitForStreamErr fully expresses; the
+// end-to-end production path is exercised by
+// [TestC7_EndToEnd_TruncationFromRealLoader] below.
 func TestC7_WaitForStreamErr_DeliversTaggedMsg(t *testing.T) {
 	errs := make(chan error, 2)
 	stream := &loader.Stream{Errs: errs}
@@ -244,6 +247,11 @@ func TestC7_EndToEnd_TruncationFromRealLoader(t *testing.T) {
 		select {
 		case msg = <-done:
 		case <-time.After(200 * time.Millisecond):
+			// Re-enqueue: a slow waitForStreamErr/waitForChunk
+			// must not be silently dropped, otherwise we'd miss
+			// the warning we're trying to assert on. The outer
+			// 2s deadline still bounds the loop.
+			queue = append(queue, c)
 			continue
 		}
 		if msg == nil {

--- a/internal/ui/stream_errs_test.go
+++ b/internal/ui/stream_errs_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -209,8 +208,14 @@ func TestC7_EndToEnd_TruncationFromRealLoader(t *testing.T) {
 	// MaxLineBytes cap.
 	body := strings.Repeat("x", 200*1024) + "\n"
 
+	// t.Cleanup-bound cancel guarantees the loader's streaming
+	// goroutine exits before the test returns, even if an assertion
+	// fails partway through.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
 	src := &fakeSource{body: body, kind: source.KindText}
-	stream, err := loader.Open(context.Background(), src, loader.Config{})
+	stream, err := loader.Open(ctx, src, loader.Config{})
 	if err != nil {
 		t.Fatalf("loader.Open: %v", err)
 	}
@@ -222,45 +227,30 @@ func TestC7_EndToEnd_TruncationFromRealLoader(t *testing.T) {
 	m.source = src
 	m.stream = stream
 
-	// Drive Init's commands and feed any streamErrMsg back into
-	// Update — same sequence Bubble Tea's runtime would execute.
+	// loader.Open consumes the 200 KiB single line during its
+	// synchronous First read, emits the truncation warning into
+	// the buffered Errs channel, then takes the EOF fast-path and
+	// closes both Updates and Errs before returning. Each cmd in
+	// Init's batch therefore reads from a populated-and-closed
+	// channel and returns promptly without blocking.
 	cmd := m.Init()
 	if cmd == nil {
 		t.Fatalf("Init returned nil — Errs subscription would never fire")
 	}
 
-	// Race the Init pipeline against a short deadline. Once we see
-	// a streamErrMsg we feed it into Update and check the
-	// advisory; once we see a chunkLoadedMsg or streamDoneMsg we
-	// move on (no warning). Either path is bounded.
-	deadline := time.Now().Add(2 * time.Second)
 	queue := []tea.Cmd{cmd}
-	for len(queue) > 0 && time.Now().Before(deadline) {
+	for len(queue) > 0 {
 		c := queue[0]
 		queue = queue[1:]
 		if c == nil {
 			continue
 		}
-		done := make(chan tea.Msg, 1)
-		go func() { done <- c() }()
-		var msg tea.Msg
-		select {
-		case msg = <-done:
-		case <-time.After(200 * time.Millisecond):
-			// Re-enqueue: a slow waitForStreamErr/waitForChunk
-			// must not be silently dropped, otherwise we'd miss
-			// the warning we're trying to assert on. The outer
-			// 2s deadline still bounds the loop.
-			queue = append(queue, c)
-			continue
-		}
+		msg := c()
 		if msg == nil {
 			continue
 		}
 		if batch, ok := msg.(tea.BatchMsg); ok {
-			for _, sub := range batch {
-				queue = append(queue, sub)
-			}
+			queue = append(queue, batch...)
 			continue
 		}
 		updated, next := m.Update(msg)

--- a/internal/ui/stream_errs_test.go
+++ b/internal/ui/stream_errs_test.go
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: 2026 Adam Poulemanos
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package ui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/knitli/spy/internal/loader"
+	"github.com/knitli/spy/internal/source"
+)
+
+// TestC7_StreamErrSurfacedAsAdvisory pins the acceptance-review C7
+// contract: a non-nil error arriving on [loader.Stream.Errs] MUST
+// surface in the UI as a status-bar advisory rather than being
+// silently dropped.
+//
+// Pre-fix the loader's Errs channel was buffered and written to
+// (via the loader's own select/default best-effort send) but never
+// drained from the production UI — when the buffer filled up the
+// `default` arm of the select discarded warnings without trace, so
+// users were never told a 100 KiB+ line was truncated or that
+// stdin scroll-back was disabled.
+func TestC7_StreamErrSurfacedAsAdvisory(t *testing.T) {
+	m := newTestModel(t, "alpha\nbeta\n")
+	wrapped := fmt.Errorf("%w: line 42", loader.ErrLineTruncated)
+
+	updated, _ := m.Update(streamErrMsg{err: wrapped, stream: m.stream})
+	got := updated.(Model).statusAdvisory
+	if got == "" {
+		t.Fatalf("statusAdvisory unset after streamErrMsg — warning silently dropped")
+	}
+	if !strings.Contains(got, "line 42") {
+		t.Errorf("statusAdvisory missing line number; got %q", got)
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Errorf("statusAdvisory missing 'truncated' marker; got %q", got)
+	}
+}
+
+// TestC7_StdinNonSeekableSurfacedAsAdvisory exercises the second
+// documented sentinel — windowed-mode entry against non-seekable
+// stdin. The renderer's wording is preserved verbatim because it
+// already explains what the user lost.
+func TestC7_StdinNonSeekableSurfacedAsAdvisory(t *testing.T) {
+	m := newTestModel(t, "x\n")
+	updated, _ := m.Update(streamErrMsg{err: loader.ErrStdinNonSeekable, stream: m.stream})
+	got := updated.(Model).statusAdvisory
+	if !strings.Contains(got, "stdin") || !strings.Contains(got, "scroll-back") {
+		t.Errorf("statusAdvisory does not surface ErrStdinNonSeekable; got %q", got)
+	}
+}
+
+// TestC7_StaleStreamErrIgnored verifies the stream-pointer guard:
+// an err arriving from a stream that ActionReload / :open has
+// swapped out must NOT overwrite the new session's advisory.
+//
+// Mirrors the same stale-message guard pattern that
+// chunkLoadedMsg / streamDoneMsg already use (Copilot review PR#8
+// #2 on the original loader wiring).
+func TestC7_StaleStreamErrIgnored(t *testing.T) {
+	m := newTestModel(t, "x\n")
+	m.statusAdvisory = "preserved"
+
+	staleStream := &loader.Stream{} // distinct pointer; no Errs needed
+	updated, _ := m.Update(streamErrMsg{err: loader.ErrLineTruncated, stream: staleStream})
+	if got := updated.(Model).statusAdvisory; got != "preserved" {
+		t.Errorf("stale streamErrMsg overrode the active advisory; got %q want %q", got, "preserved")
+	}
+}
+
+// TestC7_NilErrSkippedReSubscribes covers a defensive edge case:
+// the loader's `select / default` send is best-effort, and a nil
+// send through that channel (theoretically impossible but cheap to
+// guard) must not corrupt the advisory. The handler should re-
+// subscribe so subsequent real warnings still arrive.
+func TestC7_NilErrSkippedReSubscribes(t *testing.T) {
+	m := newTestModel(t, "x\n")
+	m.statusAdvisory = "preserved"
+
+	updated, cmd := m.Update(streamErrMsg{err: nil, stream: m.stream})
+	if got := updated.(Model).statusAdvisory; got != "preserved" {
+		t.Errorf("nil streamErrMsg overrode the active advisory; got %q want %q", got, "preserved")
+	}
+	if cmd == nil {
+		t.Errorf("nil streamErrMsg did not re-subscribe — subsequent warnings would never arrive")
+	}
+}
+
+// TestC7_FormatStreamErr_Sentinels covers the per-sentinel string
+// shaping. Loader wraps ErrLineTruncated as `"%w: line N"` —
+// formatStreamErr surfaces the line number first ("more relevant to
+// the user") and the cause second.
+func TestC7_FormatStreamErr_Sentinels(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantSubstr []string
+	}{
+		{
+			name:       "line_truncated_wrapped",
+			err:        fmt.Errorf("%w: line 100", loader.ErrLineTruncated),
+			wantSubstr: []string{"line 100", "truncated"},
+		},
+		{
+			name:       "stdin_non_seekable_verbatim",
+			err:        loader.ErrStdinNonSeekable,
+			wantSubstr: []string{"stdin", "scroll-back"},
+		},
+		{
+			name:       "unknown_error_wrapped",
+			err:        errors.New("synthetic loader fault"),
+			wantSubstr: []string{"loader:", "synthetic loader fault"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatStreamErr(tc.err)
+			for _, sub := range tc.wantSubstr {
+				if !strings.Contains(got, sub) {
+					t.Errorf("formatStreamErr(%v) = %q; want substring %q", tc.err, got, sub)
+				}
+			}
+		})
+	}
+}
+
+// TestC7_Init_SubscribesToErrsChannel proves the Init pipeline
+// includes waitForStreamErr — without it, a real warning emitted
+// by the loader's truncation path would never reach a subscriber.
+//
+// The test drives a synthetic stream whose Errs channel has a
+// pre-injected warning, calls waitForStreamErr directly, and
+// asserts the resulting cmd yields a streamErrMsg carrying that
+// warning.
+//
+// We don't drive Init() end-to-end here — that returns a tea.Batch
+// whose order is implementation-detail and whose subordinate cmds
+// can block on an empty Errs channel. The contract that matters is
+// "subscribed AND tagged correctly", which waitForStreamErr fully
+// expresses.
+func TestC7_WaitForStreamErr_DeliversTaggedMsg(t *testing.T) {
+	errs := make(chan error, 2)
+	stream := &loader.Stream{Errs: errs}
+
+	// Inject a warning so the cmd has something to read; no real
+	// loader is running.
+	errs <- fmt.Errorf("%w: line 7", loader.ErrLineTruncated)
+
+	cmd := waitForStreamErr(stream)
+	if cmd == nil {
+		t.Fatalf("waitForStreamErr returned nil — production wiring would have no subscriber")
+	}
+	msg := cmd()
+	got, ok := msg.(streamErrMsg)
+	if !ok {
+		t.Fatalf("cmd did not yield streamErrMsg; got %T (%v)", msg, msg)
+	}
+	if got.stream != stream {
+		t.Errorf("streamErrMsg.stream mismatch — stale-stream guard would misfire")
+	}
+	if !errors.Is(got.err, loader.ErrLineTruncated) {
+		t.Errorf("streamErrMsg.err did not carry the injected sentinel; got %v", got.err)
+	}
+}
+
+// TestC7_WaitForStreamErr_NilOnClose covers the channel-closed
+// branch. The loader closes Errs after Updates, so a closed Errs
+// signals "streaming has fully ended". We return nil so the
+// Bubble Tea command machinery treats it as a no-op rather than
+// dispatching a misleading streamErrMsg with a zero-value error.
+func TestC7_WaitForStreamErr_NilOnClose(t *testing.T) {
+	errs := make(chan error)
+	close(errs)
+	stream := &loader.Stream{Errs: errs}
+
+	cmd := waitForStreamErr(stream)
+	if cmd == nil {
+		t.Fatalf("waitForStreamErr returned nil cmd before invocation")
+	}
+	if msg := cmd(); msg != nil {
+		t.Errorf("cmd on closed Errs returned non-nil msg %T (%v); expected nil", msg, msg)
+	}
+}
+
+// TestC7_EndToEnd_TruncationFromRealLoader is the production-path
+// integration: drive the actual loader against a source whose first
+// line exceeds MaxLineBytes, run the model through Init() and a
+// short event loop, then confirm the truncation warning surfaced
+// in m.statusAdvisory.
+//
+// This exercises the full chain: bufio.Scanner → readChunk's
+// per-line cap → loader's errs send → waitForStreamErr → Update's
+// onStreamErr → m.statusAdvisory. Each step in isolation has a
+// unit test above; this one proves the wires connect.
+func TestC7_EndToEnd_TruncationFromRealLoader(t *testing.T) {
+	// 200 KiB single line — well past the default 100 KiB
+	// MaxLineBytes cap.
+	body := strings.Repeat("x", 200*1024) + "\n"
+
+	src := &fakeSource{body: body, kind: source.KindText}
+	stream, err := loader.Open(context.Background(), src, loader.Config{})
+	if err != nil {
+		t.Fatalf("loader.Open: %v", err)
+	}
+	if stream == nil {
+		t.Fatalf("loader.Open returned nil stream")
+	}
+
+	m := newTestModel(t, "ignored") // hold the model shape
+	m.source = src
+	m.stream = stream
+
+	// Drive Init's commands and feed any streamErrMsg back into
+	// Update — same sequence Bubble Tea's runtime would execute.
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatalf("Init returned nil — Errs subscription would never fire")
+	}
+
+	// Race the Init pipeline against a short deadline. Once we see
+	// a streamErrMsg we feed it into Update and check the
+	// advisory; once we see a chunkLoadedMsg or streamDoneMsg we
+	// move on (no warning). Either path is bounded.
+	deadline := time.Now().Add(2 * time.Second)
+	queue := []tea.Cmd{cmd}
+	for len(queue) > 0 && time.Now().Before(deadline) {
+		c := queue[0]
+		queue = queue[1:]
+		if c == nil {
+			continue
+		}
+		done := make(chan tea.Msg, 1)
+		go func() { done <- c() }()
+		var msg tea.Msg
+		select {
+		case msg = <-done:
+		case <-time.After(200 * time.Millisecond):
+			continue
+		}
+		if msg == nil {
+			continue
+		}
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				queue = append(queue, sub)
+			}
+			continue
+		}
+		updated, next := m.Update(msg)
+		m = updated.(Model)
+		if next != nil {
+			queue = append(queue, next)
+		}
+		if strings.Contains(m.statusAdvisory, "truncated") {
+			return // success
+		}
+	}
+	t.Fatalf("statusAdvisory never received truncation warning; final=%q", m.statusAdvisory)
+}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -31,9 +31,10 @@ import (
 // in the UI as they happen.
 //
 // Pre-acceptance review the Errs channel was unconsumed in production
-// — `WarnLineTruncated` and `WarnStdinNonSeekable` warnings reached
-// the channel and were silently dropped, so users were never told
-// content was clipped or that scroll-back was disabled (review C7).
+// — `loader.ErrLineTruncated` and `loader.ErrStdinNonSeekable`
+// warnings reached the channel and were silently dropped, so users
+// were never told content was clipped or that scroll-back was
+// disabled (review C7).
 func (m Model) Init() tea.Cmd {
 	if m.stream == nil {
 		return nil
@@ -1150,11 +1151,13 @@ func waitForChunk(s *loader.Stream) tea.Cmd {
 }
 
 // waitForStreamErr subscribes to the loader's Errs channel and
-// yields each non-nil warning / error as a tea.Msg tagged with the
-// originating stream. The handler in [Model.Update] uses the tag
-// to drop stale warnings from a stream that ActionReload / :open
-// has already swapped out (matches the [waitForChunk] tagging
-// convention).
+// forwards each received warning / error as a tea.Msg tagged with
+// the originating stream. The handler in [Model.Update] uses the
+// tag to drop stale warnings from a stream that ActionReload /
+// :open has already swapped out (matches the [waitForChunk]
+// tagging convention), and [Model.onStreamErr] guards against the
+// theoretical nil-error case from the loader's best-effort
+// `select / default` send.
 //
 // Returns nil when the channel closes — the loader closes Errs
 // after Updates closes, so a closed Errs always means streaming has

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -1159,10 +1159,14 @@ func waitForChunk(s *loader.Stream) tea.Cmd {
 // theoretical nil-error case from the loader's best-effort
 // `select / default` send.
 //
-// Returns nil when the channel closes — the loader closes Errs
-// after Updates closes, so a closed Errs always means streaming has
-// fully ended; we don't need a sentinel "errs done" message because
-// streamDoneMsg already covers the streaming-finished transition.
+// Returns nil when the channel closes. A closed Errs means this
+// stream will not emit any more warnings / errors, regardless of
+// whether Updates has already closed (the loader closes them in
+// different orders depending on whether streaming finished
+// synchronously in [loader.Open] or asynchronously on the producer
+// goroutine — defers fire LIFO). We don't need a separate "errs
+// done" sentinel because streamDoneMsg remains the signal for the
+// streaming-finished transition.
 //
 // Acceptance review C7: before this command existed, the loader's
 // errs channel was buffered, written to, and never read — when the

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -6,6 +6,7 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -23,14 +24,21 @@ import (
 	"github.com/knitli/spy/internal/source"
 )
 
-// Init sets up the initial command pipeline: subscribe to the loader's
-// Updates channel via [waitForChunk] and seed the viewport with the
-// first chunk's content.
+// Init sets up the initial command pipeline: subscribe to BOTH the
+// loader's Updates channel (via [waitForChunk]) AND its Errs channel
+// (via [waitForStreamErr]) so progressive content arrivals AND
+// non-fatal warnings (line-truncated, stdin-non-seekable) surface
+// in the UI as they happen.
+//
+// Pre-acceptance review the Errs channel was unconsumed in production
+// — `WarnLineTruncated` and `WarnStdinNonSeekable` warnings reached
+// the channel and were silently dropped, so users were never told
+// content was clipped or that scroll-back was disabled (review C7).
 func (m Model) Init() tea.Cmd {
 	if m.stream == nil {
 		return nil
 	}
-	return waitForChunk(m.stream)
+	return tea.Batch(waitForChunk(m.stream), waitForStreamErr(m.stream))
 }
 
 // Update routes Bubble Tea messages to the matching handler. The
@@ -60,6 +68,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.status = render.StatusIdle
 		}
 		return m, metaUpdatedCmd(m.stream)
+	case streamErrMsg:
+		return m.onStreamErr(msg)
 	case reloadMsg:
 		return m.onReload()
 	case reloadResultMsg:
@@ -141,9 +151,16 @@ func (m Model) onOpenResult(msg openResultMsg) (tea.Model, tea.Cmd) {
 	}
 	m.viewport.SetContent(m.renderer.Render(m.renderContext()))
 	if m.streaming {
-		return m, waitForChunk(m.stream)
+		// Re-subscribe to BOTH chunks AND errs against the new
+		// stream — without re-subscribing to errs, the swapped-in
+		// source's truncation / stdin warnings would never reach
+		// the UI (acceptance review C7).
+		return m, tea.Batch(waitForChunk(m.stream), waitForStreamErr(m.stream))
 	}
-	return m, nil
+	// Even on EOF stream we should subscribe once so a buffered
+	// warning from `loader.Open` (e.g. truncation in the first
+	// chunk read synchronously) still surfaces.
+	return m, waitForStreamErr(m.stream)
 }
 
 // onResize reflows the viewport to the new terminal size. The status
@@ -831,6 +848,59 @@ func (m Model) onChunk(msg chunkLoadedMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// onStreamErr translates a [loader.Stream.Errs] arrival into a
+// status-bar advisory and re-subscribes for the next warning.
+//
+// Stale-stream guard mirrors [chunkLoadedMsg] / [streamDoneMsg]:
+// warnings from an old stream that ActionReload or :open replaced
+// must not surface against the new session.
+//
+// nil errors are skipped (re-subscription only); they shouldn't
+// happen in practice but the loader's `select / default` send is
+// best-effort and a nil send would corrupt the advisory.
+func (m Model) onStreamErr(msg streamErrMsg) (tea.Model, tea.Cmd) {
+	if msg.stream != nil && msg.stream != m.stream {
+		return m, nil
+	}
+	if msg.err == nil {
+		return m, waitForStreamErr(m.stream)
+	}
+	m.statusAdvisory = formatStreamErr(msg.err)
+	return m, waitForStreamErr(m.stream)
+}
+
+// formatStreamErr renders a [loader.Stream.Errs] error into a
+// terse one-line advisory suitable for the status bar.
+//
+// The two documented sentinels (per loader/stream.go:74-80) are:
+//   - ErrLineTruncated, wrapped as "%w: line N" — surfaced as
+//     "line N truncated (cap exceeded)" so the user sees both the
+//     fact and the affected location.
+//   - ErrStdinNonSeekable — surfaced verbatim because the existing
+//     wording already explains what the user lost ("scroll-back
+//     disabled past resident window").
+//
+// Anything else falls through to the wrapped error string. The
+// status bar collapses below 80 cols and drops the advisory anyway,
+// so we keep the format short but informative.
+func formatStreamErr(err error) string {
+	if errors.Is(err, loader.ErrLineTruncated) {
+		// The loader wraps with line number: "line truncated: line N".
+		// Re-shape so the line number leads (more relevant to the
+		// user) and the cause follows.
+		s := err.Error()
+		if idx := strings.LastIndex(s, "line "); idx >= 0 {
+			lineN := s[idx:]
+			return lineN + " truncated (cap exceeded)"
+		}
+		return "line truncated (cap exceeded)"
+	}
+	if errors.Is(err, loader.ErrStdinNonSeekable) {
+		return err.Error()
+	}
+	return "loader: " + err.Error()
+}
+
 // metaUpdatedCmd returns a tea.Cmd that yields a [metaUpdatedMsg]
 // carrying the buffer's pinned total. nil-safe for streams without a
 // buffer (degenerate test models).
@@ -898,9 +968,12 @@ func (m Model) onReloadResult(msg reloadResultMsg) (tea.Model, tea.Cmd) {
 	}
 	m.viewport.SetContent(m.renderer.Render(m.renderContext()))
 	if m.streaming {
-		return m, waitForChunk(m.stream)
+		// Re-subscribe to BOTH chunks AND errs after a reload —
+		// see the matching comment in [Model.onOpenResult] for
+		// the C7 background.
+		return m, tea.Batch(waitForChunk(m.stream), waitForStreamErr(m.stream))
 	}
-	return m, nil
+	return m, waitForStreamErr(m.stream)
 }
 
 // loaderConfigFromConfig pulls the loader-shaped fields out of the
@@ -1073,5 +1146,36 @@ func waitForChunk(s *loader.Stream) tea.Cmd {
 			return streamDoneMsg{stream: s}
 		}
 		return chunkLoadedMsg{chunk: c, stream: s}
+	}
+}
+
+// waitForStreamErr subscribes to the loader's Errs channel and
+// yields each non-nil warning / error as a tea.Msg tagged with the
+// originating stream. The handler in [Model.Update] uses the tag
+// to drop stale warnings from a stream that ActionReload / :open
+// has already swapped out (matches the [waitForChunk] tagging
+// convention).
+//
+// Returns nil when the channel closes — the loader closes Errs
+// after Updates closes, so a closed Errs always means streaming has
+// fully ended; we don't need a sentinel "errs done" message because
+// streamDoneMsg already covers the streaming-finished transition.
+//
+// Acceptance review C7: before this command existed, the loader's
+// errs channel was buffered, written to, and never read — when the
+// channel filled up the loader's `select / default` non-blocking
+// send dropped subsequent warnings silently, so users were never
+// told a 100 KiB+ line was truncated or that stdin scroll-back
+// was disabled.
+func waitForStreamErr(s *loader.Stream) tea.Cmd {
+	if s == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		err, ok := <-s.Errs
+		if !ok {
+			return nil
+		}
+		return streamErrMsg{err: err, stream: s}
 	}
 }


### PR DESCRIPTION
## Summary

Last remaining CRITICAL finding from the spec-001 acceptance review. Wires the loader's `Stream.Errs` channel into the existing status-advisory pipeline so truncation warnings and stdin-non-seekable warnings actually reach the user.

## Problem

`internal/loader/stream.go:65-72` documents \`Stream.Errs\` as the side-channel for non-fatal warnings:
- \`ErrLineTruncated\` — a single line exceeded \`MaxLineBytes\` and was clipped
- \`ErrStdinNonSeekable\` — windowed-mode entered against non-seekable stdin so scroll-back is unavailable past the resident region

Pre-fix the channel had no production consumer:

\`\`\`bash
$ grep -rn "stream\\.Errs\\|\\.Errs\\b" internal/ cmd/ --include='*.go' | grep -v _test.go
internal/loader/stream.go:72:    # comment only
internal/loader/window.go:309:   # comment only
\`\`\`

The loader's \`select / default\` send is best-effort, so once the buffered channel filled the warnings were silently dropped. Users got zero notification.

## Changes

**\`internal/ui/model.go\`** — new \`streamErrMsg{err, stream}\` carrying both the warning AND the originating stream pointer (stale-stream guard parity with \`chunkLoadedMsg\` / \`streamDoneMsg\`).

**\`internal/ui/update.go\`**:
- \`waitForStreamErr\` cmd analogous to \`waitForChunk\` for the Errs channel
- \`onStreamErr\` handler routes through \`formatStreamErr\` → \`m.statusAdvisory\` and re-subscribes for the next warning
- \`formatStreamErr\` shaper: surfaces line number first for truncation, preserves verbatim wording of \`ErrStdinNonSeekable\`, generic \`loader: <err>\` prefix for unknowns
- \`Init\` returns \`tea.Batch(waitForChunk, waitForStreamErr)\`
- \`onOpenResult\` and \`onReloadResult\` re-batch both subscriptions after a stream swap so the new session's warnings reach the UI

## Tests — \`internal/ui/stream_errs_test.go\` (9 cases)

| Test | Pins |
|---|---|
| \`TestC7_StreamErrSurfacedAsAdvisory\` | line N + \"truncated\" reach \`m.statusAdvisory\` |
| \`TestC7_StdinNonSeekableSurfacedAsAdvisory\` | sentinel #2 surfaces |
| \`TestC7_StaleStreamErrIgnored\` | pointer guard (parity with chunkLoadedMsg) |
| \`TestC7_NilErrSkippedReSubscribes\` | defensive nil-send guard |
| \`TestC7_FormatStreamErr_Sentinels\` | per-sentinel string shapes (table) |
| \`TestC7_WaitForStreamErr_DeliversTaggedMsg\` | cmd carries the originating stream pointer |
| \`TestC7_WaitForStreamErr_NilOnClose\` | closed-channel returns nil |
| \`TestC7_EndToEnd_TruncationFromRealLoader\` | production-path integration: 200 KiB single line through real \`loader.Open\` → Init() → Update() → \`m.statusAdvisory\` carries truncation marker |

## Validation

| Check | Result |
|---|---|
| \`go build ./... + -tags fitz\` | PASS |
| \`go vet ./... + -tags fitz\` | PASS |
| \`go test -race -count=1 ./...\` | PASS (13 packages) |
| \`go test ./tests/perf/...\` | PASS (~17s) |
| \`reuse lint\` | PASS (269/269) |
| \`make lint && make vet\` | PASS |

## Acceptance review status

This was the **last** remaining CRITICAL finding. C1–C6 closed in #15.

| # | Status |
|---|---|
| C1 — 8 PTY tests skipped | ✅ #15 |
| C2 — wrong SIGINT/SIGTERM exit codes | ✅ #15 |
| C3 — perf gate not run by CI | ✅ #15 |
| C4 — escape neutralization bypassed | ✅ #15 |
| C5 — false security checklist claim | ✅ #15 |
| C6 — missing fixture dirs | ✅ #15 |
| **C7 — Stream.Errs unconsumed** | ✅ **this PR** |

## Test plan

- [ ] CI \`test\` job: lint + vet + race + perf + cover gate all green
- [ ] Manual: \`spy <very-long-line-file.txt>\` shows the line-truncated advisory in the footer
- [ ] Manual: \`(curl very-long-stream | spy)\` shows the stdin-non-seekable advisory once windowed-mode kicks in

🤖 Generated with [Claude Code](https://claude.com/claude-code)