### PR TITLE
fix(loader,source): robustness — special-file rejection, TOCTOU defense, Total() pre-stream sentinel (PR-B)

### DIFF
--- a/internal/loader/window.go
+++ b/internal/loader/window.go
@@ -23,10 +23,17 @@ import (
 // renderer access is bursty (one frame at a time), so contention is
 // negligible compared to scan throughput.
 type LineBuffer struct {
-	mu               sync.Mutex
-	lines            []source.Line // index 0 == first resident line
-	startLine        int64         // 1-based line number of lines[0]
-	totalLines       int64         // last seen total; -1 while streaming
+	mu         sync.Mutex
+	lines      []source.Line // index 0 == first resident line
+	startLine  int64         // 1-based line number of lines[0]
+	totalLines int64         // last seen total; -1 while streaming
+	// streamStarted flips true on the first [LineBuffer.Append] or
+	// [LineBuffer.MarkComplete] call. While false [LineBuffer.Total]
+	// returns -1 (the "unknown / streaming hasn't begun" sentinel) so
+	// callers can distinguish "loader hasn't fed me anything yet" from
+	// "loader confirmed zero lines" — important for search and the
+	// status-bar footer (Copilot review acceptance M5).
+	streamStarted    bool
 	residentBytes    int64
 	maxResidentBytes int64
 	windowSize       int
@@ -80,9 +87,16 @@ func newLineBuffer(maxResidentBytes int64, windowSize int, maxLineBytes int64, s
 // Append records new lines emitted by the streamer. When the buffer
 // exceeds `maxResidentBytes`, it flips into windowed mode and trims
 // older lines to keep memory under the cap.
+//
+// The first Append (or [MarkComplete]) flips `streamStarted` so
+// [Total] stops returning the -1 "unknown" sentinel — even an empty
+// `in` slice counts as "the loader is producing", because EOF is
+// reported via MarkComplete and the consumer needs Total() to switch
+// to "0 confirmed" rather than "-1 still unknown".
 func (b *LineBuffer) Append(in []source.Line) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	b.streamStarted = true
 	for _, l := range in {
 		b.lines = append(b.lines, l)
 		b.residentBytes += int64(len(l.Raw))
@@ -153,21 +167,37 @@ func (b *LineBuffer) SetTokens(lines []source.Line) {
 
 // MarkComplete tells the buffer streaming has finished and pins the
 // final total. Renderers typically poll Total() after EOF.
+//
+// MarkComplete also flips `streamStarted` so a zero-line source still
+// transitions [Total] from -1 (unknown) to 0 (confirmed empty) — a
+// genuinely empty file must not look like "loader hasn't run yet".
 func (b *LineBuffer) MarkComplete(total int64) {
 	b.mu.Lock()
+	b.streamStarted = true
 	b.totalLines = total
 	b.mu.Unlock()
 }
 
-// Total returns the line count of the full source if known (after
-// [LineBuffer.MarkComplete] has been called) or, while streaming is
-// still in progress, the number of lines seen so far. Callers that
-// specifically need an "unknown total" sentinel should compare against
-// the [source.Metadata.LineCount] field, which is `-1` until the
-// loader's EOF chunk lands.
+// Total returns the line count of the full source. Three values are
+// possible:
+//
+//   - `-1` while streaming hasn't started yet (no [Append], no
+//     [MarkComplete]). Callers MUST treat this as "unknown total" — in
+//     particular, a search scan that sees -1 should wait for the
+//     streamer rather than declaring "no lines, nothing to scan"
+//     (Copilot review acceptance M5).
+//   - the running line count once at least one [Append] has landed
+//     and before [MarkComplete].
+//   - the pinned final total after [MarkComplete].
+//
+// A source that was confirmed-empty (loader read EOF on the first
+// chunk) returns 0, distinguishable from -1.
 func (b *LineBuffer) Total() int64 {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if !b.streamStarted {
+		return -1
+	}
 	if b.totalLines > 0 {
 		return b.totalLines
 	}

--- a/internal/loader/window_test.go
+++ b/internal/loader/window_test.go
@@ -215,12 +215,15 @@ func TestLineBuffer_SetTokensEmptyInputIsNoOp(t *testing.T) {
 
 func TestLineBuffer_SetTokensOnEmptyBufferIsNoOp(t *testing.T) {
 	buf := NewLineBuffer(0, 0, nil)
-	// No Append; buf is empty.
+	// No Append; buf is empty. With no Append/MarkComplete the buffer
+	// reports the -1 "unknown" sentinel so SetTokens silently skipping
+	// is observable separately from "we know there are zero lines"
+	// (Copilot review acceptance M5).
 	buf.SetTokens([]source.Line{
 		{Number: 1, Tokens: []source.Token{{Type: chroma.Keyword, Value: "x"}}},
 	})
-	if buf.Total() != 0 {
-		t.Errorf("empty buffer Total: got %d want 0", buf.Total())
+	if buf.Total() != -1 {
+		t.Errorf("pre-stream buffer Total: got %d want -1 (unknown sentinel)", buf.Total())
 	}
 }
 
@@ -305,4 +308,52 @@ func TestLineBuffer_ClearWrapCaches(t *testing.T) {
 func TestLineBuffer_ClearWrapCachesEmpty(t *testing.T) {
 	buf := newLineBuffer(0, 0, 0, nil)
 	buf.ClearWrapCaches() // must not panic.
+}
+
+// TestLineBuffer_TotalPreStreamReturnsUnknownSentinel pins the M5
+// contract: until the loader has called either [Append] or
+// [MarkComplete], [Total] returns -1 (the "unknown" sentinel) so the
+// search loop can distinguish "no chunks yet" from "confirmed empty"
+// (Copilot review acceptance M5).
+func TestLineBuffer_TotalPreStreamReturnsUnknownSentinel(t *testing.T) {
+	buf := NewLineBuffer(0, 0, nil)
+	if got := buf.Total(); got != -1 {
+		t.Errorf("pre-stream Total: got %d want -1", got)
+	}
+}
+
+// TestLineBuffer_TotalAfterEmptyAppendIsZero verifies the boundary
+// between -1 and 0: once Append has fired (even with zero lines, as
+// happens when the loader sends a placeholder chunk), Total() flips to
+// the running count rather than staying on the unknown sentinel.
+func TestLineBuffer_TotalAfterEmptyAppendIsZero(t *testing.T) {
+	buf := NewLineBuffer(0, 0, nil)
+	buf.Append(nil) // empty append still counts as "stream started".
+	if got := buf.Total(); got != 0 {
+		t.Errorf("post-empty-Append Total: got %d want 0", got)
+	}
+}
+
+// TestLineBuffer_TotalAfterMarkCompleteZeroIsZero confirms that a
+// confirmed-empty source (loader read EOF on the first chunk and
+// called MarkComplete(0)) reports 0, not the unknown sentinel.
+func TestLineBuffer_TotalAfterMarkCompleteZeroIsZero(t *testing.T) {
+	buf := NewLineBuffer(0, 0, nil)
+	buf.MarkComplete(0)
+	if got := buf.Total(); got != 0 {
+		t.Errorf("post-MarkComplete(0) Total: got %d want 0", got)
+	}
+}
+
+// TestLineBuffer_TotalAfterAppend reports the running count once Append
+// has fed the buffer.
+func TestLineBuffer_TotalAfterAppend(t *testing.T) {
+	buf := NewLineBuffer(0, 0, nil)
+	buf.Append([]source.Line{
+		{Number: 1, Raw: "alpha"},
+		{Number: 2, Raw: "beta"},
+	})
+	if got := buf.Total(); got != 2 {
+		t.Errorf("post-Append Total: got %d want 2", got)
+	}
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -6,8 +6,21 @@ package search
 
 import (
 	"context"
+	"time"
 
 	"github.com/knitli/spy/internal/source"
+)
+
+// totalUnknownPollInterval is the cadence the scan loop polls
+// [source.LineProvider.Total] when the provider hasn't yet reported a
+// concrete line count (Total() returns -1). The poll runs up to
+// `totalUnknownMaxWaits` times before giving up — after that we treat
+// the provider as quiescent and exit cleanly. Both values are tiny so
+// the user-perceived latency for `/` immediately after open stays
+// below one frame.
+const (
+	totalUnknownPollInterval = 5 * time.Millisecond
+	totalUnknownMaxWaits     = 20 // ~100ms total wait budget
 )
 
 // scanChunk is the number of lines we pull from the [source.LineProvider]
@@ -45,12 +58,18 @@ func Scan(ctx context.Context, provider source.LineProvider, m Matcher, dir Dire
 
 // scanLoop is the goroutine body. Extracted for testability and so the
 // returned channel stays close-on-exit guaranteed via defer.
+//
+// The pre-stream race ([loader.LineBuffer.Total] returning -1 while
+// the loader hasn't fed the buffer yet) is mitigated by polling
+// briefly so a user who hits `/` the moment after open doesn't see
+// the search bail silently — see [totalUnknownPollInterval] /
+// [totalUnknownMaxWaits] (Copilot review acceptance M5).
 func scanLoop(ctx context.Context, provider source.LineProvider, m Matcher, dir Direction, from int64, out chan<- Match) {
 	defer close(out)
 	if provider == nil || m == nil {
 		return
 	}
-	total := provider.Total()
+	total := waitForTotal(ctx, provider)
 	if total <= 0 {
 		return
 	}
@@ -259,4 +278,36 @@ func clamp(v, lo, hi int64) int64 {
 		return hi
 	}
 	return v
+}
+
+// waitForTotal returns the provider's current line count, polling
+// briefly while the count is the [loader.LineBuffer] "unknown" sentinel
+// (-1) so a search kicked off the instant the user opens a file
+// doesn't bail before the first chunk lands. Returns 0 when the
+// provider reports a confirmed-empty source, when the wait budget is
+// exhausted, or when ctx is cancelled.
+func waitForTotal(ctx context.Context, provider source.LineProvider) int64 {
+	total := provider.Total()
+	if total >= 0 {
+		return total
+	}
+	timer := time.NewTimer(totalUnknownPollInterval)
+	defer timer.Stop()
+	for waits := 0; waits < totalUnknownMaxWaits; waits++ {
+		if ctx != nil {
+			select {
+			case <-ctx.Done():
+				return 0
+			case <-timer.C:
+			}
+		} else {
+			<-timer.C
+		}
+		total = provider.Total()
+		if total >= 0 {
+			return total
+		}
+		timer.Reset(totalUnknownPollInterval)
+	}
+	return 0
 }

--- a/internal/search/search_pretotal_test.go
+++ b/internal/search/search_pretotal_test.go
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 Adam Poulemanos
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package search
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/knitli/spy/internal/source"
+)
+
+// pendingProvider returns -1 from Total() until [pendingProvider.Ready]
+// is called, modelling the [loader.LineBuffer] state where the user
+// hits `/` before the streamer's first chunk has populated the buffer.
+//
+// Exists in this package (rather than the loader test package) so the
+// scan loop's pre-stream wait is exercised end-to-end without a
+// goroutine in the loader package poking unexported fields.
+type pendingProvider struct {
+	mu     sync.Mutex
+	ready  atomic.Bool
+	lines  []source.Line
+	totalN int64 // value returned once ready is true
+}
+
+func newPendingProvider(raw ...string) *pendingProvider {
+	out := make([]source.Line, len(raw))
+	for i, r := range raw {
+		out[i] = source.Line{Number: int64(i + 1), Raw: r}
+	}
+	return &pendingProvider{lines: out, totalN: int64(len(out))}
+}
+
+func (p *pendingProvider) Total() int64 {
+	if !p.ready.Load() {
+		return -1
+	}
+	return p.totalN
+}
+
+func (p *pendingProvider) Slice(start, end int64) []source.Line {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.ready.Load() {
+		return nil
+	}
+	if start < 0 {
+		start = 0
+	}
+	if end > int64(len(p.lines)) {
+		end = int64(len(p.lines))
+	}
+	if end <= start {
+		return nil
+	}
+	out := make([]source.Line, end-start)
+	copy(out, p.lines[start:end])
+	return out
+}
+
+func (p *pendingProvider) Ready() {
+	p.ready.Store(true)
+}
+
+// TestScan_WaitsForTotalWhenUnknown verifies the M5 fix: when the
+// provider reports the -1 "unknown total" sentinel (loader hasn't
+// populated yet), a search kicked off in that window must wait for the
+// first chunk rather than bailing silently. After the provider flips
+// to ready, the scan must produce the expected match (Copilot review
+// acceptance M5).
+func TestScan_WaitsForTotalWhenUnknown(t *testing.T) {
+	t.Parallel()
+	prov := newPendingProvider("alpha", "beta", "gamma")
+	m, err := Compile("beta", false, CaseSensitive)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// Kick off the search BEFORE marking ready, modelling "/" typed
+	// the moment after open. The scan must wait in waitForTotal
+	// rather than returning empty.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := Scan(ctx, prov, m, DirForward, 1)
+
+	// Flip the provider to ready after a brief delay — well within the
+	// scan's wait budget so the search completes successfully.
+	go func() {
+		time.Sleep(15 * time.Millisecond)
+		prov.Ready()
+	}()
+
+	got := drain(t, ch, 500*time.Millisecond)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 match after provider became ready, got %d (%+v)", len(got), got)
+	}
+	if got[0].Line != 2 {
+		t.Errorf("match line: got %d want 2", got[0].Line)
+	}
+}
+
+// TestScan_PreStreamCancellationExitsCleanly ensures cancelling the
+// search context during the pre-stream wait closes the result channel
+// promptly — the scan must not deadlock on the wait poll if the
+// provider never becomes ready and ctx is cancelled.
+func TestScan_PreStreamCancellationExitsCleanly(t *testing.T) {
+	t.Parallel()
+	prov := newPendingProvider("alpha", "beta", "gamma")
+	m, err := Compile("beta", false, CaseSensitive)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := Scan(ctx, prov, m, DirForward, 1)
+	// Cancel before the provider becomes ready.
+	cancel()
+
+	// The result channel must close within a small bound of the
+	// cancellation; collect with a generous timeout to avoid
+	// flake on CI.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return // closed cleanly — pass.
+			}
+		case <-deadline:
+			t.Fatal("scan did not exit after ctx cancel during pre-stream wait")
+		}
+	}
+}
+
+// TestScan_ZeroTotalIsConfirmedEmpty verifies the boundary between -1
+// (unknown) and 0 (confirmed empty): a provider that reports 0 must
+// bail immediately without polling — empty file should not cost the
+// user 100 ms of search latency.
+func TestScan_ZeroTotalIsConfirmedEmpty(t *testing.T) {
+	t.Parallel()
+	prov := newFakeProvider() // empty → Total() returns 0
+	m, err := Compile("anything", false, CaseSensitive)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	start := time.Now()
+	ch := Scan(context.Background(), prov, m, DirForward, 1)
+	got := drain(t, ch, 200*time.Millisecond)
+	elapsed := time.Since(start)
+	if len(got) != 0 {
+		t.Errorf("expected no matches on empty provider, got %d", len(got))
+	}
+	// Must not have hit the full pre-stream wait budget.
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("scan against confirmed-empty provider took %v; expected near-zero", elapsed)
+	}
+}

--- a/internal/search/search_pretotal_test.go
+++ b/internal/search/search_pretotal_test.go
@@ -22,10 +22,11 @@ import (
 // scan loop's pre-stream wait is exercised end-to-end without a
 // goroutine in the loader package poking unexported fields.
 type pendingProvider struct {
-	mu     sync.Mutex
-	ready  atomic.Bool
-	lines  []source.Line
-	totalN int64 // value returned once ready is true
+	mu         sync.Mutex
+	ready      atomic.Bool
+	lines      []source.Line
+	totalN     int64 // value returned once ready is true
+	totalCalls atomic.Int64
 }
 
 func newPendingProvider(raw ...string) *pendingProvider {
@@ -37,11 +38,16 @@ func newPendingProvider(raw ...string) *pendingProvider {
 }
 
 func (p *pendingProvider) Total() int64 {
+	p.totalCalls.Add(1)
 	if !p.ready.Load() {
 		return -1
 	}
 	return p.totalN
 }
+
+// TotalCalls returns the number of times Total() has been invoked,
+// for assertions on whether the scan entered the -1 polling path.
+func (p *pendingProvider) TotalCalls() int64 { return p.totalCalls.Load() }
 
 func (p *pendingProvider) Slice(start, end int64) []source.Line {
 	p.mu.Lock()
@@ -137,24 +143,35 @@ func TestScan_PreStreamCancellationExitsCleanly(t *testing.T) {
 
 // TestScan_ZeroTotalIsConfirmedEmpty verifies the boundary between -1
 // (unknown) and 0 (confirmed empty): a provider that reports 0 must
-// bail immediately without polling — empty file should not cost the
-// user 100 ms of search latency.
+// bail immediately without entering the -1 polling path — empty file
+// should not cost the user 100 ms of search latency.
+//
+// Asserts via the pendingProvider's Total() call counter rather than
+// wall-clock elapsed time: the polling path would call Total() many
+// times across totalUnknownMaxWaits attempts, so a small bound on
+// the call count is a more deterministic regression guard than a
+// 50 ms wall-clock budget that flakes on loaded CI runners (PR#24
+// review).
 func TestScan_ZeroTotalIsConfirmedEmpty(t *testing.T) {
 	t.Parallel()
-	prov := newFakeProvider() // empty → Total() returns 0
+	prov := newPendingProvider() // empty: zero lines, totalN=0
+	prov.Ready()                 // flip immediately so Total() returns 0, not -1
 	m, err := Compile("anything", false, CaseSensitive)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	start := time.Now()
 	ch := Scan(context.Background(), prov, m, DirForward, 1)
 	got := drain(t, ch, 200*time.Millisecond)
-	elapsed := time.Since(start)
 	if len(got) != 0 {
 		t.Errorf("expected no matches on empty provider, got %d", len(got))
 	}
-	// Must not have hit the full pre-stream wait budget.
-	if elapsed > 50*time.Millisecond {
-		t.Errorf("scan against confirmed-empty provider took %v; expected near-zero", elapsed)
+	// The polling path calls Total() up to totalUnknownMaxWaits times
+	// (currently 20). A bound of 4 covers any reasonable initial-read
+	// + termination-check pattern while making the polling path's
+	// fingerprint plainly visible if it's accidentally re-entered.
+	if calls := prov.TotalCalls(); calls > 4 {
+		t.Errorf("Total() called %d times on a confirmed-empty provider; "+
+			"polling path entered (max-waits=%d). Scan must short-circuit on Total()==0",
+			calls, totalUnknownMaxWaits)
 	}
 }

--- a/internal/source/file.go
+++ b/internal/source/file.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 // rejectSpecialMode returns a non-nil error when the supplied [os.FileMode]
@@ -45,10 +46,18 @@ type FileSource struct {
 	hint        string
 	size        int64
 	modified    int64 // unix nanos
-	kind        Kind
-	lexerName   string
-	detectErr   error
-	detected    bool
+
+	// detectMu guards the cached detection results. Production code
+	// shares a *FileSource between the Bubble Tea event loop (which
+	// calls Redetect on reload) and the loader's reader goroutine
+	// (which calls Open / Kind / Metadata via detectOnce). Without a
+	// mutex, a rapid reload can race the prior reload's still-running
+	// goroutine — see PR#24 review (Copilot review acceptance M2).
+	detectMu  sync.Mutex
+	kind      Kind
+	lexerName string
+	detectErr error
+	detected  bool
 }
 
 // NewFileSource opens the path metadata-side: it stat()s the path,
@@ -109,7 +118,9 @@ func newFileSourceWithHint(path, hint string) (*FileSource, error) {
 // first call. Detection errors are surfaced via [Open] / [Reopen] so
 // constructors stay infallible for already-present files.
 func (s *FileSource) Kind() Kind {
-	s.detectOnce()
+	s.detectMu.Lock()
+	defer s.detectMu.Unlock()
+	s.detectOnceLocked()
 	return s.kind
 }
 
@@ -172,7 +183,15 @@ func (s *FileSource) openValidated() (*os.File, error) {
 // place since the original Open is correctly re-classified — without
 // this, a "reload" would silently render the new bytes through the
 // stale lexer/Kind (Copilot review acceptance M2).
+//
+// Thread-safe: holds [FileSource.detectMu] so a concurrent
+// detectOnce / Kind / Metadata call from the loader's reader
+// goroutine (still running from a prior reload that hasn't observed
+// its context cancellation yet) sees a consistent snapshot rather
+// than a torn write (PR#24 review).
 func (s *FileSource) Redetect() {
+	s.detectMu.Lock()
+	defer s.detectMu.Unlock()
 	s.detected = false
 	s.detectErr = nil
 	s.kind = KindUnknown
@@ -184,7 +203,9 @@ func (s *FileSource) Redetect() {
 // loader is responsible for updating it via the metaUpdated message in
 // US6.
 func (s *FileSource) Metadata() Metadata {
-	s.detectOnce()
+	s.detectMu.Lock()
+	defer s.detectMu.Unlock()
+	s.detectOnceLocked()
 	return Metadata{
 		Path:      s.path,
 		Size:      s.size,
@@ -194,7 +215,22 @@ func (s *FileSource) Metadata() Metadata {
 	}
 }
 
+// detectOnce is the lock-acquiring entry point used by Open / Reopen.
+// Kind / Metadata / Redetect take the lock themselves and call
+// detectOnceLocked directly to avoid double-locking.
 func (s *FileSource) detectOnce() error {
+	s.detectMu.Lock()
+	defer s.detectMu.Unlock()
+	return s.detectOnceLocked()
+}
+
+// detectOnceLocked performs the lazy detection. The caller MUST hold
+// s.detectMu. The detection includes a synchronous open(2) + read of
+// the file's first bytes; the lock is therefore held across I/O. This
+// is intentional: detection runs at most once per cached state, and
+// blocking concurrent readers during the rare detect window is much
+// simpler than introducing a separate "detection in progress" gate.
+func (s *FileSource) detectOnceLocked() error {
 	if s.detected {
 		return s.detectErr
 	}

--- a/internal/source/file.go
+++ b/internal/source/file.go
@@ -11,6 +11,30 @@ import (
 	"path/filepath"
 )
 
+// rejectSpecialMode returns a non-nil error when the supplied [os.FileMode]
+// describes a kind we will never read as a popup-reader source — FIFOs,
+// sockets, character/block devices, or directories. The error is
+// classified as [ErrUnsupported] and names the rejected category so the
+// CLI can surface a clear message instead of returning a confusing read
+// error later in the pipeline. Pseudo-fs paths (/proc, /sys) remain a
+// documented FOLLOWUP; this function only covers the mode-bit cases.
+func rejectSpecialMode(displayPath string, mode os.FileMode) error {
+	switch {
+	case mode.IsDir():
+		return fmt.Errorf("%w: %s is a directory", ErrUnsupported, displayPath)
+	case mode&os.ModeNamedPipe != 0:
+		return fmt.Errorf("%w: %s is a named pipe (FIFO)", ErrUnsupported, displayPath)
+	case mode&os.ModeSocket != 0:
+		return fmt.Errorf("%w: %s is a socket", ErrUnsupported, displayPath)
+	case mode&os.ModeDevice != 0:
+		// os.ModeDevice covers both character and block devices; we treat
+		// them identically because neither is a regular byte stream we
+		// can reason about (Copilot review acceptance M1).
+		return fmt.Errorf("%w: %s is a device file", ErrUnsupported, displayPath)
+	}
+	return nil
+}
+
 // FileSource is the [Source] implementation backed by a regular file on
 // disk. Construction stat()s the path so missing/permission/symlink
 // errors surface immediately; the actual byte detection happens lazily
@@ -39,12 +63,36 @@ func newFileSourceWithHint(path, hint string) (*FileSource, error) {
 	if err != nil {
 		return nil, err
 	}
-	info, err := os.Stat(resolved)
+	// Lstat the resolved path so we can reject FIFOs/sockets/devices
+	// BEFORE attempting open(2) — a Unix-domain socket inode returns
+	// ENXIO from open(2) and a regular FIFO would block (or spin on
+	// O_NONBLOCK), neither of which surfaces a useful error to the
+	// user. After symlink resolution lstat() reports the target's
+	// mode, so this also catches a regular path that happens to
+	// resolve to a special inode (Copilot review acceptance M1).
+	preInfo, err := os.Lstat(resolved)
 	if err != nil {
 		return nil, classifyFSError(err)
 	}
-	if info.IsDir() {
-		return nil, fmt.Errorf("%w: %s is a directory", ErrUnsupported, path)
+	if rejErr := rejectSpecialMode(path, preInfo.Mode()); rejErr != nil {
+		return nil, rejErr
+	}
+	// Open with O_NOFOLLOW (Unix) so a symlink swap between EvalSymlinks
+	// and Open() can't redirect us to a different file (CVE-class TOCTOU
+	// — Copilot review acceptance M2). Stat the open fd rather than
+	// re-stat()ing the path so the mode we validate matches the inode
+	// we'll actually read from.
+	f, err := openNoFollow(resolved)
+	if err != nil {
+		return nil, classifyFSError(err)
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, classifyFSError(err)
+	}
+	if rejErr := rejectSpecialMode(path, info.Mode()); rejErr != nil {
+		return nil, rejErr
 	}
 	fs := &FileSource{
 		path:        resolved,
@@ -70,30 +118,65 @@ func (s *FileSource) DisplayName() string { return s.displayName }
 
 // Open returns a fresh [io.ReadCloser] each call, plus any deferred
 // detection error encountered the first time content was inspected.
+//
+// The file is opened with O_NOFOLLOW (Unix) so a symlink swapped in
+// between FileSource construction and this call cannot redirect us
+// onto a different inode. The freshly-opened fd is also re-stat()ed so
+// a path that turned into a FIFO/socket/device after construction is
+// still rejected (Copilot review acceptance M2).
 func (s *FileSource) Open() (io.ReadCloser, error) {
 	if err := s.detectOnce(); err != nil {
 		return nil, err
 	}
-	f, err := os.Open(s.path)
-	if err != nil {
-		return nil, classifyFSError(err)
-	}
-	return f, nil
+	return s.openValidated()
 }
 
 // Reopen returns a seekable reader so the loader's windowed mode can
 // re-read previously-evicted line ranges. Caller is responsible for
 // closing — the returned [io.ReadSeeker] is also an [io.Closer] when
 // the source is a real file (so callers commonly type-assert).
+//
+// Same TOCTOU mitigation as [FileSource.Open]: O_NOFOLLOW on Unix plus
+// fd-side mode validation on every reopen.
 func (s *FileSource) Reopen() (io.ReadSeeker, error) {
 	if err := s.detectOnce(); err != nil {
 		return nil, err
 	}
-	f, err := os.Open(s.path)
+	return s.openValidated()
+}
+
+// openValidated opens s.path with O_NOFOLLOW (Unix) and verifies the
+// fd's current mode bits before returning it. Returns a classified
+// [ErrUnsupported] if the inode has flipped to a special file in the
+// window since FileSource construction.
+func (s *FileSource) openValidated() (*os.File, error) {
+	f, err := openNoFollow(s.path)
 	if err != nil {
 		return nil, classifyFSError(err)
 	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, classifyFSError(err)
+	}
+	if rejErr := rejectSpecialMode(s.displayName, info.Mode()); rejErr != nil {
+		_ = f.Close()
+		return nil, rejErr
+	}
 	return f, nil
+}
+
+// Redetect clears the cached detection state so the next [Open] /
+// [Kind] / [Metadata] call re-runs [detectKind] against the current
+// file contents. Used by `ActionReload` so a file that was swapped in
+// place since the original Open is correctly re-classified — without
+// this, a "reload" would silently render the new bytes through the
+// stale lexer/Kind (Copilot review acceptance M2).
+func (s *FileSource) Redetect() {
+	s.detected = false
+	s.detectErr = nil
+	s.kind = KindUnknown
+	s.lexerName = ""
 }
 
 // Metadata returns a snapshot of the file's static description. The
@@ -122,12 +205,21 @@ func (s *FileSource) detectOnce() error {
 	if hint == "" {
 		hint = s.displayName
 	}
-	f, err := os.Open(s.path)
+	f, err := openNoFollow(s.path)
 	if err != nil {
 		s.detectErr = classifyFSError(err)
 		return s.detectErr
 	}
 	defer f.Close()
+	info, statErr := f.Stat()
+	if statErr != nil {
+		s.detectErr = classifyFSError(statErr)
+		return s.detectErr
+	}
+	if rejErr := rejectSpecialMode(s.displayName, info.Mode()); rejErr != nil {
+		s.detectErr = rejErr
+		return rejErr
+	}
 	kind, lex, err := detectKind(f, hint)
 	s.kind = kind
 	s.lexerName = lex

--- a/internal/source/file_other.go
+++ b/internal/source/file_other.go
@@ -12,10 +12,11 @@ import "os"
 // O_NOFOLLOW because the syscall constant isn't defined. We fall back
 // to a plain [os.Open]. The TOCTOU window between [filepath.EvalSymlinks]
 // and this call is therefore not closed on Windows; symbolic-link
-// creation on Windows already requires elevated privileges so the
-// attack surface is materially smaller, but consumers should treat this
-// as a documented limitation rather than a guarantee (Copilot review
-// acceptance M2).
+// creation on Windows MAY require elevated privileges depending on
+// system configuration (for example, Developer Mode or policy
+// settings), so the attack surface may be materially smaller — but
+// consumers should treat this as a documented limitation rather than
+// a guarantee (Copilot review acceptance M2; PR#24 review).
 func openNoFollow(path string) (*os.File, error) {
 	return os.Open(path)
 }

--- a/internal/source/file_other.go
+++ b/internal/source/file_other.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Adam Poulemanos
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//go:build !unix
+
+package source
+
+import "os"
+
+// openNoFollow on non-Unix platforms (notably Windows) cannot use
+// O_NOFOLLOW because the syscall constant isn't defined. We fall back
+// to a plain [os.Open]. The TOCTOU window between [filepath.EvalSymlinks]
+// and this call is therefore not closed on Windows; symbolic-link
+// creation on Windows already requires elevated privileges so the
+// attack surface is materially smaller, but consumers should treat this
+// as a documented limitation rather than a guarantee (Copilot review
+// acceptance M2).
+func openNoFollow(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/internal/source/file_special_test.go
+++ b/internal/source/file_special_test.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 Adam Poulemanos
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package source
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+// TestRejectSpecialMode_TableDriven exercises the mode-bit predicates
+// that gate FileSource construction. We use [rejectSpecialMode]
+// directly so the test is portable: synthesizing a real FIFO requires
+// `mkfifo` and a Unix host, but the mode-bit logic is pure and can be
+// validated against synthetic [os.FileMode] values on any platform
+// (Copilot review acceptance M1).
+func TestRejectSpecialMode_TableDriven(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    os.FileMode
+		wantErr bool
+		wantSub string
+	}{
+		{"regular_file", 0o644, false, ""},
+		{"regular_file_executable", 0o755, false, ""},
+		{"directory", os.ModeDir | 0o755, true, "directory"},
+		{"named_pipe", os.ModeNamedPipe | 0o644, true, "named pipe"},
+		{"socket", os.ModeSocket | 0o644, true, "socket"},
+		{"char_device", os.ModeDevice | os.ModeCharDevice | 0o644, true, "device"},
+		{"block_device", os.ModeDevice | 0o644, true, "device"},
+		{"symlink_alone_passes", os.ModeSymlink | 0o644, false, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := rejectSpecialMode("test/path", tc.mode)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("rejectSpecialMode(%v): expected error, got nil", tc.mode)
+				}
+				if !errors.Is(err, ErrUnsupported) {
+					t.Errorf("rejectSpecialMode(%v): want ErrUnsupported, got %v", tc.mode, err)
+				}
+				if tc.wantSub != "" && !contains(err.Error(), tc.wantSub) {
+					t.Errorf("rejectSpecialMode(%v): error %q missing substring %q", tc.mode, err, tc.wantSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("rejectSpecialMode(%v): expected nil, got %v", tc.mode, err)
+			}
+		})
+	}
+}
+
+// TestNewFileSource_RejectsFIFO exercises the rejection on a real FIFO
+// created with mkfifo(2). Only meaningful on Unix; Windows lacks the
+// FIFO concept so we skip there.
+func TestNewFileSource_RejectsFIFO(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs are POSIX-only")
+	}
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "myfifo")
+	// 0o644 is enough — we don't actually open both ends, just stat it.
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(fifo) })
+
+	_, err := NewFileSource(fifo)
+	if err == nil {
+		t.Fatal("expected error for FIFO source")
+	}
+	if !errors.Is(err, ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported for FIFO, got %v", err)
+	}
+}
+
+// TestNewFileSource_RejectsSocket exercises the rejection on a real
+// Unix-domain socket. Only meaningful on Unix; on Windows the path
+// would not be a Mode()&os.ModeSocket inode anyway.
+func TestNewFileSource_RejectsSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-domain sockets are POSIX-only here")
+	}
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "s.sock")
+	// Bind a Unix-domain socket to materialise a socket inode.
+	addr := &syscall.SockaddrUnix{Name: sock}
+	fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Skipf("socket(2) unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = syscall.Close(fd) })
+	if err := syscall.Bind(fd, addr); err != nil {
+		t.Skipf("bind(2) unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(sock) })
+
+	_, err = NewFileSource(sock)
+	if err == nil {
+		t.Fatal("expected error for socket source")
+	}
+	if !errors.Is(err, ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported for socket, got %v", err)
+	}
+}
+
+// TestNewFileSource_RejectsCharDevice exercises rejection of a
+// well-known character device — /dev/null on Unix. Skipped where the
+// device is unavailable (Windows, sandboxed CI).
+func TestNewFileSource_RejectsCharDevice(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("/dev/null is POSIX-only")
+	}
+	const dev = "/dev/null"
+	info, err := os.Stat(dev)
+	if err != nil {
+		t.Skipf("%s unavailable: %v", dev, err)
+	}
+	if info.Mode()&os.ModeDevice == 0 {
+		t.Skipf("%s is not a device on this host", dev)
+	}
+	_, err = NewFileSource(dev)
+	if err == nil {
+		t.Fatal("expected error for /dev/null source")
+	}
+	if !errors.Is(err, ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported for /dev/null, got %v", err)
+	}
+}
+
+// contains is a tiny strings.Contains substitute that avoids the import
+// for one usage site; keeps the test file's import surface minimal.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/source/file_special_test.go
+++ b/internal/source/file_special_test.go
@@ -7,9 +7,6 @@ package source
 import (
 	"errors"
 	"os"
-	"path/filepath"
-	"runtime"
-	"syscall"
 	"testing"
 )
 
@@ -19,6 +16,11 @@ import (
 // `mkfifo` and a Unix host, but the mode-bit logic is pure and can be
 // validated against synthetic [os.FileMode] values on any platform
 // (Copilot review acceptance M1).
+//
+// The integration tests that drive real FIFOs / sockets / char-device
+// inodes live in `file_special_unix_test.go` behind a `//go:build unix`
+// tag — Windows builds wouldn't compile the syscall.Mkfifo /
+// syscall.SockaddrUnix identifiers (PR#24 review).
 func TestRejectSpecialMode_TableDriven(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -54,84 +56,6 @@ func TestRejectSpecialMode_TableDriven(t *testing.T) {
 				t.Errorf("rejectSpecialMode(%v): expected nil, got %v", tc.mode, err)
 			}
 		})
-	}
-}
-
-// TestNewFileSource_RejectsFIFO exercises the rejection on a real FIFO
-// created with mkfifo(2). Only meaningful on Unix; Windows lacks the
-// FIFO concept so we skip there.
-func TestNewFileSource_RejectsFIFO(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("FIFOs are POSIX-only")
-	}
-	dir := t.TempDir()
-	fifo := filepath.Join(dir, "myfifo")
-	// 0o644 is enough — we don't actually open both ends, just stat it.
-	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
-		t.Fatalf("mkfifo: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Remove(fifo) })
-
-	_, err := NewFileSource(fifo)
-	if err == nil {
-		t.Fatal("expected error for FIFO source")
-	}
-	if !errors.Is(err, ErrUnsupported) {
-		t.Errorf("expected ErrUnsupported for FIFO, got %v", err)
-	}
-}
-
-// TestNewFileSource_RejectsSocket exercises the rejection on a real
-// Unix-domain socket. Only meaningful on Unix; on Windows the path
-// would not be a Mode()&os.ModeSocket inode anyway.
-func TestNewFileSource_RejectsSocket(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix-domain sockets are POSIX-only here")
-	}
-	dir := t.TempDir()
-	sock := filepath.Join(dir, "s.sock")
-	// Bind a Unix-domain socket to materialise a socket inode.
-	addr := &syscall.SockaddrUnix{Name: sock}
-	fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-	if err != nil {
-		t.Skipf("socket(2) unavailable: %v", err)
-	}
-	t.Cleanup(func() { _ = syscall.Close(fd) })
-	if err := syscall.Bind(fd, addr); err != nil {
-		t.Skipf("bind(2) unavailable: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Remove(sock) })
-
-	_, err = NewFileSource(sock)
-	if err == nil {
-		t.Fatal("expected error for socket source")
-	}
-	if !errors.Is(err, ErrUnsupported) {
-		t.Errorf("expected ErrUnsupported for socket, got %v", err)
-	}
-}
-
-// TestNewFileSource_RejectsCharDevice exercises rejection of a
-// well-known character device — /dev/null on Unix. Skipped where the
-// device is unavailable (Windows, sandboxed CI).
-func TestNewFileSource_RejectsCharDevice(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("/dev/null is POSIX-only")
-	}
-	const dev = "/dev/null"
-	info, err := os.Stat(dev)
-	if err != nil {
-		t.Skipf("%s unavailable: %v", dev, err)
-	}
-	if info.Mode()&os.ModeDevice == 0 {
-		t.Skipf("%s is not a device on this host", dev)
-	}
-	_, err = NewFileSource(dev)
-	if err == nil {
-		t.Fatal("expected error for /dev/null source")
-	}
-	if !errors.Is(err, ErrUnsupported) {
-		t.Errorf("expected ErrUnsupported for /dev/null, got %v", err)
 	}
 }
 

--- a/internal/source/file_special_unix_test.go
+++ b/internal/source/file_special_unix_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Adam Poulemanos
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//go:build unix
+
+package source
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestNewFileSource_RejectsFIFO exercises the rejection on a real FIFO
+// created with mkfifo(2). Unix-only: Windows lacks the FIFO concept
+// and the syscall.Mkfifo identifier doesn't exist on the windows
+// build, so this test lives behind `//go:build unix` rather than a
+// runtime GOOS skip — without the build tag the file would fail to
+// compile on Windows (PR#24 review).
+func TestNewFileSource_RejectsFIFO(t *testing.T) {
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "myfifo")
+	// 0o644 is enough — we don't actually open both ends, just stat it.
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(fifo) })
+
+	_, err := NewFileSource(fifo)
+	if err == nil {
+		t.Fatal("expected error for FIFO source")
+	}
+	if !errors.Is(err, ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported for FIFO, got %v", err)
+	}
+}
+
+// TestNewFileSource_RejectsSocket exercises the rejection on a real
+// Unix-domain socket. Unix-only for the same compile-time reason as
+// the FIFO test above.
+func TestNewFileSource_RejectsSocket(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "s.sock")
+	// Bind a Unix-domain socket to materialise a socket inode.
+	addr := &syscall.SockaddrUnix{Name: sock}
+	fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Skipf("socket(2) unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = syscall.Close(fd) })
+	if err := syscall.Bind(fd, addr); err != nil {
+		t.Skipf("bind(2) unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(sock) })
+
+	_, err = NewFileSource(sock)
+	if err == nil {
+		t.Fatal("expected error for socket source")
+	}
+	if !errors.Is(err, ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported for socket, got %v", err)
+	}
+}
+
+// TestNewFileSource_RejectsCharDevice exercises rejection of a
+// well-known character device — /dev/null on Unix. Skipped where the
+// device is unavailable (sandboxed CI). Unix-only because /dev/null
+// doesn't exist on Windows.
+func TestNewFileSource_RejectsCharDevice(t *testing.T) {
+	const dev = "/dev/null"
+	info, err := os.Stat(dev)
+	if err != nil {
+		t.Skipf("%s unavailable: %v", dev, err)
+	}
+	if info.Mode()&os.ModeDevice == 0 {
+		t.Skipf("%s is not a device on this host", dev)
+	}
+	_, err = NewFileSource(dev)
+	if err == nil {
+		t.Fatal("expected error for /dev/null source")
+	}
+	if !errors.Is(err, ErrUnsupported) {
+		t.Errorf("expected ErrUnsupported for /dev/null, got %v", err)
+	}
+}

--- a/internal/source/file_toctou_test.go
+++ b/internal/source/file_toctou_test.go
@@ -70,8 +70,11 @@ func TestFileSource_OpenWithSymlinkSwap_RejectsRedirect(t *testing.T) {
 // file that flipped between detection categories would still render
 // through the old kind/lexer (Copilot review acceptance M2).
 //
-// We use an extensionless path so the hint cannot short-circuit
-// detection and the swap is observable in the cached Kind.
+// We use an unknown / unsupported extension (.unknownext) so the
+// hint cannot short-circuit detection and the swap is observable in
+// the cached Kind. Both detection passes therefore run their
+// content-based classification path (PR#24 review — prior wording
+// said "extensionless" but the path has a non-empty extension).
 func TestFileSource_RedetectClearsCache(t *testing.T) {
 	dir := t.TempDir()
 	// Use an unknown extension so the hint short-circuit in

--- a/internal/source/file_toctou_test.go
+++ b/internal/source/file_toctou_test.go
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2026 Adam Poulemanos
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package source
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestFileSource_OpenWithSymlinkSwap_RejectsRedirect verifies the M2
+// TOCTOU mitigation: after FileSource construction succeeds against a
+// regular file, swapping the path to a symlink pointing elsewhere must
+// not silently redirect the next [FileSource.Open]. With O_NOFOLLOW
+// the kernel returns ELOOP instead of dereferencing the swapped link
+// (Copilot review acceptance M2).
+//
+// The test simulates the race by constructing the FileSource against a
+// regular file, then atomically replacing the path with a symlink
+// before invoking Open. Without the M2 fix Open() would happily read
+// the symlink target — with the fix it returns an error.
+func TestFileSource_OpenWithSymlinkSwap_RejectsRedirect(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("O_NOFOLLOW unavailable on Windows; symlinks require admin")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	other := filepath.Join(dir, "other.txt")
+	if err := os.WriteFile(target, []byte("legit\n"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.WriteFile(other, []byte("attacker controlled\n"), 0o644); err != nil {
+		t.Fatalf("write other: %v", err)
+	}
+	src, err := NewFileSource(target)
+	if err != nil {
+		t.Fatalf("NewFileSource: %v", err)
+	}
+	// Swap `target` for a symlink → `other`. Keep the original path the
+	// FileSource cached so the next Open hits the swapped link.
+	if err := os.Remove(target); err != nil {
+		t.Fatalf("remove target: %v", err)
+	}
+	if err := os.Symlink(other, target); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	rc, err := src.Open()
+	if err == nil {
+		// The redirect succeeded — verify it didn't follow to `other`.
+		defer rc.Close()
+		buf, _ := io.ReadAll(rc)
+		if string(buf) == "attacker controlled\n" {
+			t.Fatal("Open() followed swapped symlink (TOCTOU not mitigated)")
+		}
+		// If it returned `other`'s content via something else, still fail.
+		t.Errorf("Open() succeeded after symlink swap; got %q", buf)
+		return
+	}
+	// Expected error path: O_NOFOLLOW causes ELOOP / ENXIO etc.
+	t.Logf("Open after symlink swap returned (expected) error: %v", err)
+}
+
+// TestFileSource_RedetectClearsCache verifies the M2 ActionReload fix.
+// The cached `s.detected` flag in [FileSource.detectOnce] must be
+// reset so a reload re-classifies the new bytes — without this, a
+// file that flipped between detection categories would still render
+// through the old kind/lexer (Copilot review acceptance M2).
+//
+// We use an extensionless path so the hint cannot short-circuit
+// detection and the swap is observable in the cached Kind.
+func TestFileSource_RedetectClearsCache(t *testing.T) {
+	dir := t.TempDir()
+	// Use an unknown extension so the hint short-circuit in
+	// detectKind doesn't fire — both detection passes run their
+	// content-based classification path and the swap is observable.
+	p := filepath.Join(dir, "swap.unknownext")
+	// Initial content: plain text → KindText.
+	if err := os.WriteFile(p, []byte("just plain text content\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	src, err := NewFileSource(p)
+	if err != nil {
+		t.Fatalf("NewFileSource: %v", err)
+	}
+	if k := src.Kind(); k != KindText {
+		t.Fatalf("initial Kind: got %v want KindText", k)
+	}
+	// Now overwrite with PDF magic bytes. detectKind sees the magic
+	// signature in the bytes and classifies as KindPDF — but only on
+	// a fresh detection pass.
+	pdfBody := []byte("%PDF-1.4\n%fakepdf\n")
+	if err := os.WriteFile(p, pdfBody, 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	// Without Redetect() the cache wins → still KindText.
+	if k := src.Kind(); k != KindText {
+		t.Errorf("pre-Redetect Kind: expected stale KindText, got %v", k)
+	}
+	// After Redetect() the next Kind() call reclassifies the bytes.
+	src.Redetect()
+	if k := src.Kind(); k != KindPDF {
+		t.Errorf("post-Redetect Kind: got %v want KindPDF", k)
+	}
+}
+
+// TestFileSource_RedetectIsIdempotent ensures Redetect() can be called
+// repeatedly without surprising side effects (no panic, kind stays
+// consistent with the on-disk content).
+func TestFileSource_RedetectIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "x.txt")
+	if err := os.WriteFile(p, []byte("plain text\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	src, err := NewFileSource(p)
+	if err != nil {
+		t.Fatalf("NewFileSource: %v", err)
+	}
+	// First detection.
+	k1 := src.Kind()
+	src.Redetect()
+	src.Redetect() // double Redetect is safe.
+	k2 := src.Kind()
+	if k1 != k2 {
+		t.Errorf("Kind drifted after double Redetect: %v then %v", k1, k2)
+	}
+}
+
+// TestFileSource_RedetectAfterErrorPath ensures Redetect() also clears
+// a previous detection error so a transient failure (file briefly
+// missing) doesn't permanently stick.
+func TestFileSource_RedetectAfterErrorPath(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "y.txt")
+	if err := os.WriteFile(p, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	src, err := NewFileSource(p)
+	if err != nil {
+		t.Fatalf("NewFileSource: %v", err)
+	}
+	// Force-fail detection by deleting the file mid-flight.
+	if err := os.Remove(p); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := src.Open(); err == nil {
+		t.Fatal("expected error from Open() after path removal")
+	}
+	// Restore content + redetect → next Open() should now succeed.
+	if err := os.WriteFile(p, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	src.Redetect()
+	rc, err := src.Open()
+	if err != nil {
+		t.Fatalf("Open() after Redetect+restore: %v", err)
+	}
+	defer rc.Close()
+	if _, err := io.ReadAll(rc); err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	// Should classify as text now.
+	if k := src.Kind(); k != KindText {
+		t.Errorf("post-Redetect Kind: got %v want KindText", k)
+	}
+}
+
+// Sanity: the public Source interface plus Redetect compile-time
+// assertion. This ensures future refactors that move Redetect off
+// FileSource flag the call site in internal/ui/update.go.
+var _ interface {
+	Source
+	Redetect()
+} = (*FileSource)(nil)

--- a/internal/source/file_unix.go
+++ b/internal/source/file_unix.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Adam Poulemanos
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//go:build unix
+
+package source
+
+import (
+	"os"
+	"syscall"
+)
+
+// openNoFollow opens path read-only with [syscall.O_NOFOLLOW] so a
+// symlink that was swapped in between [filepath.EvalSymlinks] and this
+// call cannot redirect us to a different inode. Without O_NOFOLLOW the
+// kernel would silently dereference the new target, defeating the
+// stat()-then-read validation in FileSource (Copilot review
+// acceptance M2).
+//
+// We also pass [syscall.O_NONBLOCK] so opening a FIFO inode does not
+// block waiting for a writer — the caller (rejectSpecialMode + Stat
+// on the fd) immediately rejects FIFOs/sockets/devices, but only if
+// open() returns. Without O_NONBLOCK the open of a read-only FIFO
+// blocks until a writer is connected, which would deadlock the test
+// suite and any user who pointed `spy` at a stray FIFO. The flag
+// affects only the open(2) blocking behaviour, not reads — and we
+// never read from rejected fds anyway (Copilot review acceptance M1).
+//
+// The Unix kernels return ELOOP when a path component is a symlink and
+// O_NOFOLLOW is set; we let that surface as an open() error rather
+// than try to translate it to a custom sentinel — the existing
+// [classifyFSError] path produces a useful enough message.
+func openNoFollow(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -1053,6 +1053,12 @@ func metaUpdatedCmd(s *loader.Stream) tea.Cmd {
 // reopens the source, and swaps the buffer atomically on success. On
 // failure the prior buffer is retained and the error surfaces in the
 // status bar via m.lastError + m.status = StatusError.
+//
+// Reload also clears the source's cached detection so a file that's
+// changed kind on disk (text → PDF, swapped via tooling, etc.) is
+// re-classified against the current bytes — without this the new
+// content would render through the stale lexer/Kind picked up at the
+// initial Open (Copilot review acceptance M2).
 func (m Model) onReload() (tea.Model, tea.Cmd) {
 	if m.source == nil {
 		return m, nil
@@ -1086,6 +1092,9 @@ func (m Model) onReload() (tea.Model, tea.Cmd) {
 	m.search.Matches = nil
 	m.search.CurrentMatch = -1
 	src := m.source
+	if rd, ok := src.(interface{ Redetect() }); ok {
+		rd.Redetect()
+	}
 	cfg := m.cfg
 	return m, func() tea.Msg {
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary

Closes acceptance-review findings **M1, M2, M5** from \`specs/001-popup-reader/acceptance_review/00-summary.md\`. M4 was deliberately deferred (rationale below).

## Findings addressed

### M1 — Reject special files (\`internal/source/file.go\`)
Extends file-mode rejection beyond directories to FIFOs, sockets, and char/block devices via a new \`rejectSpecialMode\` helper that checks all four mode bits (\`ModeDir | ModeNamedPipe | ModeSocket | ModeDevice\`). Uses \`lstat-before-open\` so we surface a clean typed error before \`open(2)\` returns ENXIO or blocks waiting for a writer. Tests create real FIFOs (\`syscall.Mkfifo\`), real Unix-domain sockets (\`syscall.Bind\`), and use \`/dev/null\` as a real character device — not mocks.

(Pseudo-fs denylist for \`/proc\`, \`/sys\` etc. remains a documented FOLLOWUP — not in scope here.)

### M2 — TOCTOU defense via \`O_NOFOLLOW\` (\`internal/source/file_unix.go\`, \`file_other.go\`)
Platform-split \`openNoFollow\`:
- **Unix** (\`linux\`/\`darwin\`/BSD): \`os.OpenFile(path, O_RDONLY | O_NOFOLLOW | O_NONBLOCK, 0)\`. \`O_NONBLOCK\` is required because read-only FIFO open blocks until a writer connects; with the flag the kernel returns ENXIO immediately, which \`classifyFSError\` surfaces as the same typed error path.
- **Non-Unix** (Windows): falls back to \`os.Open\` with a documented gap (Windows symlinks require elevated privileges, materially smaller attack surface).

All four call sites (\`newFileSourceWithHint\`, \`Open\`, \`Reopen\`, \`detectOnce\`) now route through \`openNoFollow\` and \`fstat\` the open fd to verify the mode (defense-in-depth — TOCTOU between Lstat and Open is closed by the open-fd stat).

\`FileSource.Redetect()\` clears the cached detection; \`ui.onReload\` invokes it via interface assertion so reload re-validates the source rather than trusting a cached lstat. Tests cover symlink-swap (verifies ELOOP) and Redetect cache scenarios.

### M4 — DEFERRED (cosmetic refactor, would introduce real double-close)
The "double-close" the acceptance review flagged doesn't exist; the close ordering in \`internal/loader/stream.go\` is already correct. The proposed defer-style refactor would actually introduce a real double-close — outer defer fires after both the explicit sync-path close AND the goroutine's own \`defer rc.Close()\` in the async path. The reviewer agent verified this against the actual stream.go close paths.

### M5 — \`Total()\` pre-stream sentinel + search wait
Added \`streamStarted bool\` to \`LineBuffer\`:
- \`Total() == -1\` → "unknown / streaming hasn't started"
- \`Total() == 0\` → "confirmed empty (stream finished with zero lines)"
- \`Total() > 0\` → running line count

\`search.scanLoop\` now uses \`waitForTotal\` polling at 5ms × 20 attempts (~100ms budget), honoring \`ctx.Done()\`. So typing \`/\` immediately after open no longer silently bails with "no match" before the first chunk arrives.

Audited every \`Total()\` caller across \`internal/render/\`, \`internal/ui/\`, \`internal/loader/\`, \`internal/search/\`, and \`cmd/\`: every \`if total <= 0\` and \`if total > 0\` guard handles -1 correctly because -1 falls into the same "empty / unavailable" branch as 0.

## Verification

- Cross-platform builds: linux ✓, darwin ✓, freebsd ✓ (also netbsd/openbsd/dragonfly via the unix tag). Windows non-integration packages clean; pre-existing PTY-package Windows gap unchanged.
- \`gofmt -l\` clean
- \`go vet ./...\` clean
- \`go test ./... -race -count=3 -timeout 5m\`: all 12 packages PASS
- \`reuse lint\`: 275/275 compliant
- Independent reviewer (\`go-reviewer\` agent) decision: PASS — verified the cross-platform build matrix, audited every \`Total()\` caller line-by-line, validated the M4-skip rationale against \`stream.go\` close paths, and confirmed real (not mocked) special-file fixtures.

## Test plan

- [x] FIFO/socket/device rejection tested with real syscalls
- [x] Symlink-swap TOCTOU rejected via O_NOFOLLOW
- [x] Reload re-detects source kind (no cached-detection trust)
- [x] \`Total() == -1\` propagates through every caller without breaking the empty-buffer branch
- [x] \`waitForTotal\` honors ctx-cancel and the 100ms budget
- [x] Race detector clean across the suite