### PR TITLE
fix: PR#26 followup — sanitize byte-preservation + openGen staleness guard

### DIFF
--- a/cmd/spy/main_test.go
+++ b/cmd/spy/main_test.go
@@ -155,10 +155,9 @@ func TestC4_StderrSanitizesHostileFilename(t *testing.T) {
 	stderr := <-done
 	// Use IndexByte directly to scan for raw ESC (0x1b) / CSI (0x9b)
 	// bytes — bytes.ContainsAny decodes the chars argument as runes,
-	// and U+FFFD (the LOW-1 replacement for ESC/CSI) is also the
-	// fallback rune for the invalid byte 0x9b on its own, so
-	// ContainsAny(stderr, "\x1b\x9b") gives false positives once the
-	// neutralizer substitutes FFFD.
+	// and 0x9b on its own is invalid UTF-8 that decodes as U+FFFD,
+	// so a stderr line containing a literal U+FFFD would
+	// false-positive the ContainsAny scan.
 	if bytes.IndexByte(stderr, 0x1b) >= 0 || bytes.IndexByte(stderr, 0x9b) >= 0 {
 		t.Errorf("stderr leaked ESC / 8-bit-CSI from hostile filename:\n  %q", stderr)
 	}

--- a/internal/render/code.go
+++ b/internal/render/code.go
@@ -180,8 +180,9 @@ func (r *codeRenderer) styleLine(l source.Line) string {
 // actually carry an OSC / DCS / CSI byte. Per-line inputs are typically
 // hundreds of bytes; the byte scan is one cache-line read in the
 // common case. Uses containsRawEscByte (not strings.ContainsAny) to
-// avoid the U+FFFD-vs-0x9b false positive that would force a
-// pointless full re-scan after Neutralize has already run upstream.
+// avoid the false positive where a literal U+FFFD in source content
+// would match the rune-decoded form of standalone 0x9b (invalid
+// UTF-8) and force a pointless full re-scan.
 func needsTokenNeutralisation(raw string) bool {
 	return containsRawEscByte(raw)
 }

--- a/internal/render/sanitize.go
+++ b/internal/render/sanitize.go
@@ -4,16 +4,12 @@
 
 package render
 
-import (
-	"strings"
-)
-
 // containsRawEscByte reports whether s carries a raw ESC (0x1b) or
 // CSI (0x9b) byte. Distinct from strings.ContainsAny because that
-// helper decodes the chars argument as runes — and U+FFFD (the
-// replacement Neutralize substitutes in) is also the fallback rune
-// for the invalid byte 0x9b on its own, which gives false positives
-// once neutralisation has already run.
+// helper decodes the chars argument as runes — and 0x9b on its own
+// is invalid UTF-8 that decodes as U+FFFD, so any source file
+// containing a literal U+FFFD would false-positive ContainsAny.
+// Walking bytes directly avoids that decode entirely.
 func containsRawEscByte(s string) bool {
 	for i := 0; i < len(s); i++ {
 		if c := s[i]; c == 0x1b || c == 0x9b {
@@ -24,12 +20,14 @@ func containsRawEscByte(s string) bool {
 }
 
 // Neutralize replaces every ESC (0x1b) and CSI (0x9b) byte in `s`
-// with the Unicode replacement character U+FFFD (`�`). Each
-// replacement byte expands to the 3-byte UTF-8 encoding (EF BF BD),
-// so the returned string is longer than the input when escapes are
-// present. Terminal-cell width math and search-match offsets that
-// use the original Raw bytes stay valid because we never reach this
-// path for offsets — only for human-visible emit boundaries.
+// with the ASCII byte `'?'`. The substitution is byte-for-byte by
+// design: len(Neutralize(s)) == len(s) and every byte position other
+// than the replaced one is unchanged. Several callers (notably
+// [applyMatchHighlights] in match.go) compute byte offsets against
+// the pre-neutralised string and slice the post-neutralised string
+// using those offsets — any change in length would misalign the
+// slices and could split a multi-byte UTF-8 sequence across a
+// highlight boundary.
 //
 // Why: a file whose content includes `\x1b]2;malicious\x07` — the OSC 2
 // "set window title" sequence — would, if rendered verbatim, change the
@@ -44,6 +42,13 @@ func containsRawEscByte(s string) bool {
 // `--allow-ansi-passthrough` flag can opt back in once the
 // SGR-but-not-OSC discriminator is wired in.
 //
+// On the choice of `'?'` over U+FFFD (the "conventional" Unicode
+// replacement): U+FFFD encodes to 3 UTF-8 bytes, which violates the
+// length-preservation invariant that callers depend on (PR#26 review).
+// `'?'` is a valid trade-off — slight ambiguity with literal question
+// marks in source files vs. correct match-highlight offsets across
+// every call site.
+//
 // Exported because cmd/spy uses it to sanitise file paths before
 // stderr error writes — every byte that reaches the user's terminal
 // is funnelled through here when it could carry attacker-controlled
@@ -55,27 +60,24 @@ func containsRawEscByte(s string) bool {
 //   - Spec T109b.c "Terminal escape injection from file content"
 //   - Acceptance review C4 "neutralizeEscapes bypassed in markdown / PDF /
 //     statusbar / image / stderr paths"
-//   - Acceptance review LOW-1 "use U+FFFD instead of '?'"
+//   - Acceptance review LOW-1 (closed WONTFIX in PR#26 review: U+FFFD
+//     proposal violates the byte-preservation invariant on which
+//     match.go applyMatchHighlights depends)
+//   - internal/render/match.go applyMatchHighlights (depends on
+//     byte-for-byte invariant)
 //   - tests/integration/escape_injection_test.go
 func Neutralize(s string) string {
 	if !containsRawEscByte(s) {
 		return s
 	}
-	var b strings.Builder
-	// Pre-size: each escape byte becomes 3 bytes; common case has only
-	// a handful of escapes so the rough upper bound (len(s)+12) is
-	// cheaper than counting escapes first.
-	b.Grow(len(s) + 12)
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		switch c {
+	b := []byte(s)
+	for i := 0; i < len(b); i++ {
+		switch b[i] {
 		case 0x1b, 0x9b:
-			b.WriteRune('�')
-		default:
-			b.WriteByte(c)
+			b[i] = '?'
 		}
 	}
-	return b.String()
+	return string(b)
 }
 
 // neutralizeEscapes is the unexported alias kept for the existing

--- a/internal/render/sanitize_test.go
+++ b/internal/render/sanitize_test.go
@@ -5,7 +5,6 @@
 package render
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -13,10 +12,9 @@ import (
 // containsRawEscByte helper so the boundary tests in this package
 // can share the byte-level check without re-implementing it. We
 // deliberately bypass strings.ContainsAny because that helper
-// decodes the chars argument as runes — and U+FFFD (the
-// replacement Neutralize substitutes in) is also the fallback rune
-// for the invalid byte 0x9b on its own, so ContainsAny(out,
-// "\x1b\x9b") gives a false positive once neutralisation has run.
+// decodes the chars argument as runes — and 0x9b on its own is
+// invalid UTF-8 that decodes as U+FFFD, so a source file containing
+// a literal U+FFFD would false-positive ContainsAny.
 func containsRawEscape(s string) bool { return containsRawEscByte(s) }
 
 // TestNeutralize_PassthroughBenign verifies the fast path: strings
@@ -38,10 +36,12 @@ func TestNeutralize_PassthroughBenign(t *testing.T) {
 	}
 }
 
-// TestNeutralize_ReplacesEscWithFFFD pins LOW-1: ESC (0x1b) and CSI
-// (0x9b) bytes are replaced with the Unicode replacement character
-// U+FFFD (encoded as 3 UTF-8 bytes EF BF BD), not a single '?'.
-func TestNeutralize_ReplacesEscWithFFFD(t *testing.T) {
+// TestNeutralize_ReplacesEscWithQuestionMark pins the post-PR#26
+// behaviour: ESC (0x1b) and CSI (0x9b) bytes are replaced with the
+// single ASCII byte `'?'`. The single-byte choice is load-bearing —
+// see TestNeutralize_PreservesByteLength for the invariant tests
+// downstream callers depend on.
+func TestNeutralize_ReplacesEscWithQuestionMark(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -52,27 +52,27 @@ func TestNeutralize_ReplacesEscWithFFFD(t *testing.T) {
 		{
 			name: "single ESC",
 			in:   "\x1b]2;evil\x07",
-			want: "�]2;evil\x07",
+			want: "?]2;evil\x07",
 		},
 		{
 			name: "single CSI 8-bit",
 			in:   "\x9b31m",
-			want: "�31m",
+			want: "?31m",
 		},
 		{
 			name: "mixed ESC and CSI",
 			in:   "before\x1bmid\x9bafter",
-			want: "before�mid�after",
+			want: "before?mid?after",
 		},
 		{
 			name: "only escapes",
 			in:   "\x1b\x9b\x1b",
-			want: "���",
+			want: "???",
 		},
 		{
 			name: "ESC adjacent to multibyte UTF-8",
 			in:   "漢\x1b字",
-			want: "漢�字",
+			want: "漢?字",
 		},
 	}
 
@@ -87,22 +87,51 @@ func TestNeutralize_ReplacesEscWithFFFD(t *testing.T) {
 			if containsRawEscape(got) {
 				t.Errorf("Neutralize(%q) leaked ESC/CSI: %q", tc.in, got)
 			}
-			// The replacement bytes are exactly the 3-byte UTF-8 of U+FFFD.
-			if !strings.Contains(got, "�") {
-				t.Errorf("Neutralize(%q) = %q; missing U+FFFD replacement", tc.in, got)
-			}
 		})
 	}
 }
 
-// TestNeutralize_ReplacementByteEncoding verifies the replacement
-// character is exactly the 3-byte UTF-8 sequence EF BF BD (U+FFFD)
-// — guards against an accidental switch to a single-byte placeholder.
-func TestNeutralize_ReplacementByteEncoding(t *testing.T) {
+// TestNeutralize_PreservesByteLength is the load-bearing invariant
+// guard for PR#26: applyMatchHighlights (match.go) computes byte
+// offsets against the pre-Neutralize string and slices the
+// post-Neutralize string with those offsets. Any change in length
+// would misalign the slices and could split a multi-byte UTF-8
+// sequence across a highlight boundary.
+//
+// If you are tempted to switch the replacement to U+FFFD or any
+// other multi-byte rune, this test will fail — and so will the
+// downstream highlight rendering. Pick a different defence.
+func TestNeutralize_PreservesByteLength(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"",
+		"plain ascii",
+		"\x1b",
+		"\x9b",
+		"\x1b\x9b\x1b\x9b",
+		"\x1b]2;evil\x07",
+		"漢\x1b字\x9b!",
+		"start\x1bmiddle\x9bend",
+	}
+	for _, in := range cases {
+		got := Neutralize(in)
+		if len(got) != len(in) {
+			t.Errorf("Neutralize(%q): len(out)=%d, len(in)=%d — byte-preservation invariant violated", in, len(got), len(in))
+		}
+	}
+}
+
+// TestNeutralize_ReplacementByteIsAscii pins the substitution byte
+// value at exactly `'?'` (0x3f). Guards against an accidental switch
+// back to a multi-byte replacement.
+func TestNeutralize_ReplacementByteIsAscii(t *testing.T) {
 	t.Parallel()
 	got := Neutralize("\x1b")
-	want := []byte{0xEF, 0xBF, 0xBD}
-	if got != string(want) {
-		t.Errorf("Neutralize(ESC) = % x, want % x (U+FFFD)", []byte(got), want)
+	if got != "?" {
+		t.Errorf("Neutralize(ESC) = %q (% x), want %q", got, []byte(got), "?")
+	}
+	if len(got) != 1 {
+		t.Errorf("Neutralize(ESC) length = %d, want 1", len(got))
 	}
 }

--- a/internal/ui/command_test.go
+++ b/internal/ui/command_test.go
@@ -480,10 +480,15 @@ func TestCommand_OpenSwapsSource(t *testing.T) {
 		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 		m = updated.(Model)
 	}
-	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd == nil {
 		t.Fatal(":open <path> should return a cmd")
 	}
+	// Propagate the post-Enter model so the openGen bump from
+	// runOpenCommand is observable when the openResultMsg arrives —
+	// the gen-staleness guard added in PR#26 review drops messages
+	// whose captured gen no longer matches m.openGen.
+	m = updated.(Model)
 	msg := cmd()
 	open, ok := msg.(openResultMsg)
 	if !ok {
@@ -492,8 +497,8 @@ func TestCommand_OpenSwapsSource(t *testing.T) {
 	if open.err != nil {
 		t.Fatalf(":open returned error: %v", open.err)
 	}
-	updated, _ := m.Update(open)
-	m = updated.(Model)
+	updated2, _ := m.Update(open)
+	m = updated2.(Model)
 	if m.source.DisplayName() == "fake.txt" {
 		t.Errorf(":open did not swap the source")
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -162,6 +162,16 @@ type Model struct {
 	// (success: ownership moves to m.cancel; error: the closure
 	// already invoked cancel before the message was sent).
 	openCancel context.CancelFunc
+
+	// openGen is bumped each time runOpenCommand dispatches a fresh
+	// :open. The async tea.Cmd captures the current value into
+	// [openResultMsg.gen]; on receipt the Update handler drops any
+	// message whose gen doesn't match the live counter. Without this,
+	// a stale openResultMsg from a cancelled prior :open would clear
+	// the m.openCancel belonging to the *current* in-flight :open and
+	// reintroduce the leak this guard was added to prevent (PR#26
+	// review). Mirrors the searchGen pattern used for H5.
+	openGen uint64
 }
 
 // NewModel constructs the viewer's Bubble Tea model. The first frame
@@ -303,6 +313,12 @@ type openResultMsg struct {
 	cancel context.CancelFunc
 	src    source.Source
 	err    error
+	// gen is the value of [Model.openGen] at the moment the
+	// originating runOpenCommand dispatched this message. Update
+	// drops the message if it no longer matches the live counter,
+	// preventing a stale result from a cancelled prior :open from
+	// clearing the m.openCancel of a newer in-flight :open.
+	gen uint64
 }
 
 // searchResultMsg carries the outcome of an asynchronous search scan.

--- a/internal/ui/open_cancel_test.go
+++ b/internal/ui/open_cancel_test.go
@@ -134,6 +134,71 @@ func TestM6_QuitCommandCancelsInFlightOpen(t *testing.T) {
 	}
 }
 
+// TestM6_StaleOpenResultDropped verifies the openGen staleness
+// guard added in PR#26 review: a stale openResultMsg (one whose gen
+// no longer matches m.openGen because a newer :open was issued in
+// the meantime) must be dropped without clearing the *current*
+// in-flight m.openCancel. Without the guard, the stale message
+// would wipe the cancel belonging to the newer open and reintroduce
+// the M6 leak this PR was intended to fix.
+func TestM6_StaleOpenResultDropped(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a.txt")
+	pathB := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(pathA, []byte("a\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile a: %v", err)
+	}
+	if err := os.WriteFile(pathB, []byte("b\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile b: %v", err)
+	}
+
+	m := newTestModel(t, "original\n")
+	m, _ = applyResize(m, 80, 24)
+
+	// First :open — capture its gen so we can fabricate a stale msg.
+	updated, _ := m.runOpenCommand(pathA)
+	m = updated.(Model)
+	staleGen := m.openGen
+
+	// Second :open — bumps gen, replaces openCancel with a fresh one.
+	updated2, _ := m.runOpenCommand(pathB)
+	m = updated2.(Model)
+	if m.openGen == staleGen {
+		t.Fatal("second runOpenCommand must bump openGen")
+	}
+	currentCancel := m.openCancel
+	if currentCancel == nil {
+		t.Fatal("second runOpenCommand must stash a fresh openCancel")
+	}
+
+	// Fabricate a stale openResultMsg from the first :open arriving
+	// late. Track whether its captured cancel was invoked by the
+	// stale-drop path (defensive teardown).
+	var staleCancelled atomic.Bool
+	staleMsg := openResultMsg{
+		err: nil,
+		src: nil,
+		gen: staleGen,
+		cancel: func() {
+			staleCancelled.Store(true)
+		},
+	}
+
+	updated3, _ := m.Update(staleMsg)
+	m = updated3.(Model)
+
+	// Critical: the current in-flight openCancel must NOT have been
+	// cleared by the stale message.
+	if m.openCancel == nil {
+		t.Fatal("stale openResultMsg cleared the current m.openCancel — guard regression")
+	}
+	// Defensive teardown should have fired on the stale carrier.
+	if !staleCancelled.Load() {
+		t.Error("stale message handler should defensively cancel the captured CancelFunc")
+	}
+}
+
 // TestM6_SecondOpenCancelsFirst verifies that issuing a second
 // `:open <path>` while the first is still in flight cancels the
 // prior in-flight loader's CancelFunc — otherwise the prior open's

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -104,11 +104,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // statusAdvisory. On success the new stream becomes the active one and
 // the renderer is rebuilt with the new source's kind / language.
 //
-// Clears m.openCancel regardless of outcome — on success ownership
-// moves to m.cancel (set below from msg.cancel); on error the
-// closure already invoked cancel before sending the message
+// Drops messages whose gen no longer matches m.openGen — those are
+// from a prior :open that was superseded before its loader.Open
+// returned. Acting on a stale message would clear the m.openCancel
+// belonging to the *current* in-flight :open, reintroducing the M6
+// quit-leak this guard was added to prevent (PR#26 review). The
+// stale closure already saw its ctx cancelled by the newer
+// runOpenCommand call, so its stream (if loader.Open returned one)
+// is being torn down regardless; we just need to not poison the
+// model state with it.
+//
+// Clears m.openCancel only on the matching-gen path — on success
+// ownership moves to m.cancel (set below from msg.cancel); on error
+// the closure already invoked cancel before sending the message
 // (acceptance review M6).
 func (m Model) onOpenResult(msg openResultMsg) (tea.Model, tea.Cmd) {
+	if msg.gen != m.openGen {
+		// Stale: defensively cancel the captured CancelFunc so the
+		// stream (if any) is torn down even though we drop the rest
+		// of the payload. The prior runOpenCommand already cancelled
+		// the parent ctx, but the captured cancel may still be the
+		// canonical handle the stream's goroutine watches.
+		if msg.cancel != nil {
+			msg.cancel()
+		}
+		return m, nil
+	}
 	m.openCancel = nil
 	if msg.err != nil {
 		m.statusAdvisory = fmt.Sprintf("open: %v", msg.err)
@@ -909,13 +930,19 @@ func (m Model) runOpenCommand(path string) (tea.Model, tea.Cmd) {
 	cfg := m.cfg
 	ctx, cancel := context.WithCancel(context.Background())
 	m.openCancel = cancel
+	// Bump the generation BEFORE capturing into the closure so a
+	// stale openResultMsg from a prior :open (whose closure captured
+	// the older gen value) is dropped on receipt — see openResultMsg
+	// staleness guard in onOpenResult, mirroring searchGen for H5.
+	m.openGen++
+	gen := m.openGen
 	return m, func() tea.Msg {
 		stream, err := loader.Open(ctx, src, loaderConfigFromConfig(cfg))
 		if err != nil {
 			cancel()
-			return openResultMsg{err: err, src: src}
+			return openResultMsg{err: err, src: src, gen: gen}
 		}
-		return openResultMsg{stream: stream, cancel: cancel, src: src}
+		return openResultMsg{stream: stream, cancel: cancel, src: src, gen: gen}
 	}
 }
 


### PR DESCRIPTION
## Summary

Two real bugs in PR #26 (now-merged), flagged by Copilot inline review comments that landed after the merge. Both shipped to main and need to be fixed forward.

### 1. `Neutralize` byte-preservation revert (`internal/render/sanitize.go`)

PR #26 implemented the LOW-1 finding by switching the ESC/CSI substitution from `'?'` (1 byte) to U+FFFD (3 UTF-8 bytes). This violated the byte-for-byte length-preservation invariant documented at `internal/render/match.go:58-60`:

> Substitutions are byte-for-byte (see neutralizeEscapes) so the precomputed match offsets stay aligned with the new (safe) bytes.

`applyMatchHighlights` computes byte offsets against the pre-neutralised string and slices the post-neutralised string with those offsets. After the U+FFFD change, any line with an escape character before a search match would emit misaligned highlights, and a slice boundary could land mid-multi-byte UTF-8 sequence.

**Fix**: revert to `'?'` substitution. The LOW-1 suggestion (U+FFFD is "the conventional choice") was correct in isolation but incompatible with this codebase's invariant. Closed as **WONTFIX with rationale** in the doc comment + a load-bearing `TestNeutralize_PreservesByteLength` regression guard so a future re-attempt fails loudly.

### 2. `openResultMsg` staleness guard (`internal/ui/update.go` + `model.go`)

PR #26's M6 fix added `m.openCancel` and unconditionally cleared it in `onOpenResult`. Copilot caught: a stale `openResultMsg` from a prior `:open` (whose `loader.Open` eventually returned despite ctx cancellation) would clear the `m.openCancel` belonging to the *current* in-flight `:open`, reintroducing the M6 leak the PR was meant to prevent.

**Fix**: add `openGen uint64` to `Model` (mirrors the `searchGen` pattern from H5). `runOpenCommand` bumps the counter and captures the value into the closure; `onOpenResult` drops messages whose gen no longer matches and defensively cancels their captured `CancelFunc` so the orphaned stream is still torn down. New `TestM6_StaleOpenResultDropped` pins the guard.

## Test Plan

- [x] `go build ./...` + `-tags fitz`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./... -race -count=2` — all 13 packages pass
- [x] New regression tests: `TestNeutralize_PreservesByteLength`, `TestM6_StaleOpenResultDropped`
- [x] `TestCommand_OpenSwapsSource` updated to propagate the post-Enter model (was discarding it; pre-fix worked because `runOpenCommand` had no observable post-mutation state the rest of the test depended on; now `m.openGen` matters)