### PR TITLE
feat: tmux display-popup overlay (frame-busting full-screen view)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,86 @@ update the overlay automatically.
 The full key contract lives in
 [specs/001-popup-reader/contracts/keys.md](specs/001-popup-reader/contracts/keys.md).
 
+## Multiplexer integration
+
+### tmux (automatic)
+
+When spy is run inside a tmux session it automatically re-launches itself
+via `tmux display-popup`, creating a full-screen floating overlay that covers
+all panes. When you quit (`q`), the popup closes and you are returned to your
+exact prior state. Requires **tmux 3.2 or later** (2020).
+
+```bash
+spy README.md      # inside tmux: opens a full-screen popup automatically
+```
+
+Pass `--no-popup` to skip this and run spy in the current pane instead:
+
+```bash
+spy --no-popup README.md
+```
+
+To disable it permanently, add an alias to your shell config:
+
+```bash
+alias spy='spy --no-popup'
+```
+
+### WezTerm
+
+WezTerm does not have a `display-popup` equivalent, but you can get a similar
+experience with a shell function that spawns spy in a new tab and switches
+back when it exits:
+
+```bash
+# Add to ~/.bashrc / ~/.zshrc
+spypop() {
+  wezterm cli spawn --new-window -- spy "$@"
+}
+```
+
+For a tighter integration, add a WezTerm key binding that opens the current
+selection in spy:
+
+```lua
+-- wezterm.lua
+local wezterm = require 'wezterm'
+local act = wezterm.action
+
+config.keys = {
+  {
+    key = 'o',
+    mods = 'CTRL|SHIFT',
+    action = act.SpawnCommandInNewTab {
+      args = { 'spy', wezterm.UNKNOWN_FILENAME }, -- replace with selection logic
+    },
+  },
+}
+```
+
+### Kitty
+
+Kitty's remote-control API supports true overlay windows. Enable it in
+`kitty.conf`:
+
+```ini
+# kitty.conf
+allow_remote_control yes
+listen_on unix:/tmp/kitty
+```
+
+Then define a shell function or alias:
+
+```bash
+# Add to ~/.bashrc / ~/.zshrc
+spypop() {
+  kitty @ launch --type=overlay --copy-env spy "$@"
+}
+```
+
+`--type=overlay` creates a floating window over the active window — the
+closest Kitty analogue to tmux's `display-popup`.
+
 ## Configuration
 
 Drop a TOML file at `$XDG_CONFIG_HOME/spy/config.toml` (falling back to

--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ alias spy='spy --no-popup'
 ### WezTerm
 
 WezTerm does not have a `display-popup` equivalent, but you can get a similar
-experience with a shell function that spawns spy in a new tab and switches
-back when it exits:
+experience with a shell function that opens spy in a new window:
 
 ```bash
 # Add to ~/.bashrc / ~/.zshrc

--- a/cmd/spy/flags.go
+++ b/cmd/spy/flags.go
@@ -30,6 +30,7 @@ type ParsedFlags struct {
 	Graphics      string
 	NoLineNumbers bool
 	NoWrap        bool
+	NoPopup       bool
 	HighlightCap  *int64 // nil when --highlight-cap was not passed
 	ConfigPath    string
 	NoConfig      bool
@@ -129,6 +130,7 @@ func buildFlagSet(pf *ParsedFlags) *flag.FlagSet {
 	fs.StringVar(&pf.Graphics, "graphics", "", `graphics: "auto"|"none"|"kitty"|"iterm2"|"sixel"`)
 	fs.BoolVar(&pf.NoLineNumbers, "no-line-numbers", false, "hide line numbers")
 	fs.BoolVar(&pf.NoWrap, "no-wrap", false, "disable soft-wrap")
+	fs.BoolVar(&pf.NoPopup, "no-popup", false, "disable automatic tmux popup re-launch")
 	fs.Func("highlight-cap", "disable syntax highlighting above this many bytes (set to 0 to disable entirely)", func(s string) error {
 		n, err := strconv.ParseInt(s, 10, 64)
 		if err != nil {

--- a/cmd/spy/main.go
+++ b/cmd/spy/main.go
@@ -74,20 +74,20 @@ func run(args []string, stdin *os.File) int {
 		return exitOK
 	}
 
-	// Tmux popup dispatch: if we're inside tmux, stdin is a TTY (not
-	// piped), and the user hasn't opted out, re-exec via tmux
+	// Tmux popup dispatch: if we're inside tmux, stdin is present and is
+	// a TTY (not piped), and the user hasn't opted out, re-exec via tmux
 	// display-popup so spy occupies the full terminal window rather than
 	// the current pane. The PopupSentinelEnv variable is injected into
 	// the shell command so the inner process skips this block.
 	if os.Getenv(term.PopupSentinelEnv) == "" &&
 		!pf.NoPopup &&
 		os.Getenv("TMUX") != "" &&
-		(stdin == nil || xterm.IsTerminal(int(stdin.Fd()))) {
-		if err := term.LaunchTmuxPopup(args); err == nil {
-			return exitOK
+		stdin != nil && xterm.IsTerminal(int(stdin.Fd())) {
+		if exitCode, err := term.LaunchTmuxPopup(args); err == nil {
+			return exitCode
 		}
-		// tmux unavailable or display-popup failed → fall through to
-		// normal pager mode rather than exiting with an error.
+		// tmux unavailable or display-popup failed to start → fall
+		// through to normal pager mode rather than exiting with an error.
 	}
 
 	// 1. Probe terminal capabilities. We defer Restore + cleanup AFTER

--- a/cmd/spy/main.go
+++ b/cmd/spy/main.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 
 	tea "github.com/charmbracelet/bubbletea"
+	xterm "golang.org/x/term"
 
 	"github.com/alecthomas/chroma/v2/styles"
 
@@ -71,6 +72,22 @@ func run(args []string, stdin *os.File) int {
 	if pf.Version {
 		fmt.Fprintf(os.Stdout, "spy %s\n", version)
 		return exitOK
+	}
+
+	// Tmux popup dispatch: if we're inside tmux, stdin is a TTY (not
+	// piped), and the user hasn't opted out, re-exec via tmux
+	// display-popup so spy occupies the full terminal window rather than
+	// the current pane. The PopupSentinelEnv variable is injected into
+	// the shell command so the inner process skips this block.
+	if os.Getenv(term.PopupSentinelEnv) == "" &&
+		!pf.NoPopup &&
+		os.Getenv("TMUX") != "" &&
+		(stdin == nil || xterm.IsTerminal(int(stdin.Fd()))) {
+		if err := term.LaunchTmuxPopup(args); err == nil {
+			return exitOK
+		}
+		// tmux unavailable or display-popup failed → fall through to
+		// normal pager mode rather than exiting with an error.
 	}
 
 	// 1. Probe terminal capabilities. We defer Restore + cleanup AFTER

--- a/internal/term/popup.go
+++ b/internal/term/popup.go
@@ -5,6 +5,7 @@
 package term
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -25,13 +26,17 @@ const PopupSentinelEnv = "_SPY_POPUP_ACTIVE"
 // prepends the PopupSentinelEnv assignment to the shell command so the
 // inner process skips re-launch.
 //
-// Returns nil on a clean popup exit (user pressed q). Returns an error if
-// tmux is not found, display-popup is unsupported, or the subprocess fails
-// to start; callers should fall through to normal pager mode on error.
-func LaunchTmuxPopup(originalArgs []string) error {
+// Returns (exitCode, nil) when the popup ran to completion — including
+// non-zero inner exits such as Ctrl-C (130) or signal-driven exits. The
+// caller should propagate exitCode directly.
+//
+// Returns (0, err) only when tmux itself could not be found or the
+// subprocess failed to start; the caller should fall through to normal
+// pager mode.
+func LaunchTmuxPopup(originalArgs []string) (int, error) {
 	exe, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("popup: resolve executable: %w", err)
+		return 0, fmt.Errorf("popup: resolve executable: %w", err)
 	}
 
 	// Build a POSIX shell command string:
@@ -57,7 +62,20 @@ func LaunchTmuxPopup(originalArgs []string) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// tmux launched and ran the popup; the inner spy process
+			// exited non-zero (e.g. Ctrl-C → 130). Return that code so
+			// the caller can propagate it without re-running spy.
+			return exitErr.ExitCode(), nil
+		}
+		// tmux not found or could not start — let the caller fall
+		// through to normal pager mode.
+		return 0, err
+	}
+	return 0, nil
 }
 
 // shellQuote wraps s in single quotes with interior single-quote characters

--- a/internal/term/popup.go
+++ b/internal/term/popup.go
@@ -5,6 +5,7 @@
 package term
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -18,6 +19,20 @@ import (
 // keeps the flag surface clean.
 const PopupSentinelEnv = "_SPY_POPUP_ACTIVE"
 
+// displayPopupAvailable reports true if the tmux binary found on PATH exposes
+// the display-popup subcommand (requires tmux ≥ 3.2). It runs
+// "tmux list-commands" to confirm capability before LaunchTmuxPopup
+// attempts to open the popup, which lets callers reliably distinguish
+// "tmux not capable" (fall through to pager) from "popup ran but inner
+// spy exited non-zero" (propagate exit code).
+func displayPopupAvailable() bool {
+	out, err := exec.Command("tmux", "list-commands").Output()
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(out, []byte("display-popup"))
+}
+
 // LaunchTmuxPopup re-execs the current spy binary inside a tmux
 // display-popup overlay that floats over all panes at full terminal size.
 // It blocks until the user dismisses the popup.
@@ -30,10 +45,14 @@ const PopupSentinelEnv = "_SPY_POPUP_ACTIVE"
 // non-zero inner exits such as Ctrl-C (130) or signal-driven exits. The
 // caller should propagate exitCode directly.
 //
-// Returns (0, err) only when tmux itself could not be found or the
-// subprocess failed to start; the caller should fall through to normal
-// pager mode.
+// Returns (0, err) only when tmux itself could not be found, does not
+// support display-popup, or the subprocess failed to start; the caller
+// should fall through to normal pager mode.
 func LaunchTmuxPopup(originalArgs []string) (int, error) {
+	if !displayPopupAvailable() {
+		return 0, fmt.Errorf("popup: display-popup not available")
+	}
+
 	exe, err := os.Executable()
 	if err != nil {
 		return 0, fmt.Errorf("popup: resolve executable: %w", err)
@@ -79,7 +98,7 @@ func LaunchTmuxPopup(originalArgs []string) (int, error) {
 }
 
 // shellQuote wraps s in single quotes with interior single-quote characters
-// replaced by the POSIX '\” escape sequence. Safe for any string value.
+// replaced by the POSIX `'\”` escape sequence. Safe for any string value.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/term/popup.go
+++ b/internal/term/popup.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 Adam Poulemanos
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package term
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// PopupSentinelEnv is the environment variable injected by LaunchTmuxPopup
+// into the shell command it passes to tmux. The re-exec'd spy process checks
+// this to avoid infinite recursion. Using an env var rather than a CLI flag
+// keeps the flag surface clean.
+const PopupSentinelEnv = "_SPY_POPUP_ACTIVE"
+
+// LaunchTmuxPopup re-execs the current spy binary inside a tmux
+// display-popup overlay that floats over all panes at full terminal size.
+// It blocks until the user dismisses the popup.
+//
+// originalArgs is argv[1:] from the calling process. LaunchTmuxPopup
+// prepends the PopupSentinelEnv assignment to the shell command so the
+// inner process skips re-launch.
+//
+// Returns nil on a clean popup exit (user pressed q). Returns an error if
+// tmux is not found, display-popup is unsupported, or the subprocess fails
+// to start; callers should fall through to normal pager mode on error.
+func LaunchTmuxPopup(originalArgs []string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("popup: resolve executable: %w", err)
+	}
+
+	// Build a POSIX shell command string:
+	//   _SPY_POPUP_ACTIVE=1 '/path/to/spy' 'arg1' 'arg2' ...
+	// The leading assignment sets the sentinel for the re-exec'd process
+	// without requiring tmux's -e flag (which was added in tmux 3.2 for
+	// display-popup but is not universally available in older 3.2 point
+	// releases). Shell variable assignment before a command is POSIX.
+	parts := make([]string, 0, len(originalArgs)+2)
+	parts = append(parts, PopupSentinelEnv+"=1")
+	parts = append(parts, shellQuote(exe))
+	for _, a := range originalArgs {
+		parts = append(parts, shellQuote(a))
+	}
+
+	cmd := exec.Command("tmux",
+		"display-popup",
+		"-E",        // close popup when the command exits
+		"-w", "100%",
+		"-h", "100%",
+		strings.Join(parts, " "),
+	)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// shellQuote wraps s in single quotes with interior single-quote characters
+// replaced by the POSIX '\'' escape sequence. Safe for any string value.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/term/popup.go
+++ b/internal/term/popup.go
@@ -49,7 +49,7 @@ func LaunchTmuxPopup(originalArgs []string) error {
 
 	cmd := exec.Command("tmux",
 		"display-popup",
-		"-E",        // close popup when the command exits
+		"-E", // close popup when the command exits
 		"-w", "100%",
 		"-h", "100%",
 		strings.Join(parts, " "),
@@ -61,7 +61,7 @@ func LaunchTmuxPopup(originalArgs []string) error {
 }
 
 // shellQuote wraps s in single quotes with interior single-quote characters
-// replaced by the POSIX '\'' escape sequence. Safe for any string value.
+// replaced by the POSIX '\” escape sequence. Safe for any string value.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/term/popup_test.go
+++ b/internal/term/popup_test.go
@@ -5,8 +5,11 @@
 package term
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"unicode"
 )
 
 func TestShellQuote(t *testing.T) {
@@ -32,15 +35,15 @@ func TestShellQuote(t *testing.T) {
 
 func TestShellQuote_SafeForShell(t *testing.T) {
 	// Verify that single-quoting a string with embedded single quotes
-	// produces a valid shell token by checking that the output only ever
-	// contains the '\'' escape and is properly bookended.
+	// produces a valid shell token: starts and ends with ', and any
+	// interior single quote is escaped via the '\'' sequence.
 	tricky := "don't stop; rm -rf / # evil"
 	q := shellQuote(tricky)
 	if !strings.HasPrefix(q, "'") {
 		t.Errorf("shellQuote result must start with single quote, got %q", q)
 	}
-	// The result must not contain an unescaped literal single quote
-	// (i.e. a ' that isn't part of the '\'' escape sequence).
+	// Strip all '\'' escape sequences, then the outer quotes; no bare
+	// single quote should remain.
 	stripped := strings.ReplaceAll(q, `'\''`, "")
 	stripped = strings.TrimPrefix(stripped, "'")
 	stripped = strings.TrimSuffix(stripped, "'")
@@ -50,13 +53,96 @@ func TestShellQuote_SafeForShell(t *testing.T) {
 }
 
 func TestPopupSentinelEnv(t *testing.T) {
-	// Constant must not be empty and must be a valid env var name.
+	// Validate that PopupSentinelEnv is a legal POSIX shell variable name:
+	// must be non-empty, start with a letter or underscore, and contain
+	// only letters, digits, or underscores. This is stricter than the old
+	// check so it would catch a change that breaks the shell assignment
+	// prefix used in LaunchTmuxPopup.
 	if PopupSentinelEnv == "" {
 		t.Fatal("PopupSentinelEnv must not be empty")
 	}
-	for _, c := range PopupSentinelEnv {
-		if !((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
-			t.Errorf("PopupSentinelEnv %q contains non-identifier character %q", PopupSentinelEnv, c)
+	for i, c := range PopupSentinelEnv {
+		valid := unicode.IsLetter(c) || c == '_' || (i > 0 && unicode.IsDigit(c))
+		if !valid {
+			t.Errorf("PopupSentinelEnv %q: character %q at position %d is not a valid POSIX identifier character",
+				PopupSentinelEnv, c, i)
 		}
+	}
+	// First character must be letter or underscore (not digit).
+	first := rune(PopupSentinelEnv[0])
+	if !unicode.IsLetter(first) && first != '_' {
+		t.Errorf("PopupSentinelEnv %q must start with a letter or underscore", PopupSentinelEnv)
+	}
+}
+
+// fakeTmux writes a minimal shell script to dir/tmux that exits with the
+// given code and returns the directory prepended PATH.
+func fakeTmux(t *testing.T, exitCode int) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := []byte("#!/bin/sh\nexit " + itoa(exitCode) + "\n")
+	path := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(path, script, 0o755); err != nil {
+		t.Fatalf("fakeTmux: write script: %v", err)
+	}
+	return dir + string(filepath.ListSeparator) + os.Getenv("PATH")
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for n > 0 {
+		pos--
+		buf[pos] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}
+
+func TestLaunchTmuxPopup_NoTmux(t *testing.T) {
+	// With an empty PATH, tmux cannot be found; LaunchTmuxPopup should
+	// return a non-nil error so the caller falls through to pager mode.
+	t.Setenv("PATH", t.TempDir()) // directory exists but holds no binaries
+	code, err := LaunchTmuxPopup([]string{"test-arg"})
+	if err == nil {
+		t.Errorf("expected error when tmux is not on PATH, got nil (code %d)", code)
+	}
+}
+
+func TestLaunchTmuxPopup_CleanExit(t *testing.T) {
+	// A fake tmux that exits 0 simulates a clean popup close (user pressed q).
+	// LaunchTmuxPopup should return (0, nil).
+	t.Setenv("PATH", fakeTmux(t, 0))
+	code, err := LaunchTmuxPopup([]string{"README.md"})
+	if err != nil {
+		t.Fatalf("unexpected error on clean exit: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("expected exit code 0, got %d", code)
+	}
+}
+
+func TestLaunchTmuxPopup_NonZeroExit(t *testing.T) {
+	// A fake tmux that exits 130 simulates the inner spy receiving Ctrl-C.
+	// LaunchTmuxPopup should propagate the code and return nil error so
+	// the caller returns 130 without re-running spy in the current pane.
+	t.Setenv("PATH", fakeTmux(t, 130))
+	code, err := LaunchTmuxPopup([]string{})
+	if err != nil {
+		t.Fatalf("non-zero popup exit must not be a launch error, got: %v", err)
+	}
+	if code != 130 {
+		t.Errorf("expected exit code 130, got %d", code)
 	}
 }

--- a/internal/term/popup_test.go
+++ b/internal/term/popup_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"unicode"
 )
 
 func TestShellQuote(t *testing.T) {
@@ -61,28 +60,41 @@ func TestPopupSentinelEnv(t *testing.T) {
 	if PopupSentinelEnv == "" {
 		t.Fatal("PopupSentinelEnv must not be empty")
 	}
+	// POSIX shell variable names are [A-Za-z_][A-Za-z0-9_]* — ASCII only.
+	// Non-ASCII letters accepted by unicode.IsLetter would break the shell
+	// assignment prefix used in LaunchTmuxPopup.
 	for i, c := range PopupSentinelEnv {
-		valid := unicode.IsLetter(c) || c == '_' || (i > 0 && unicode.IsDigit(c))
+		isASCIILetter := (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+		isASCIIDigit := c >= '0' && c <= '9'
+		valid := isASCIILetter || c == '_' || (i > 0 && isASCIIDigit)
 		if !valid {
 			t.Errorf("PopupSentinelEnv %q: character %q at position %d is not a valid POSIX identifier character",
 				PopupSentinelEnv, c, i)
 		}
 	}
-	// First character must be letter or underscore (not digit).
+	// First character must be an ASCII letter or underscore (not a digit).
 	first := rune(PopupSentinelEnv[0])
-	if !unicode.IsLetter(first) && first != '_' {
-		t.Errorf("PopupSentinelEnv %q must start with a letter or underscore", PopupSentinelEnv)
+	isASCIILetter := (first >= 'A' && first <= 'Z') || (first >= 'a' && first <= 'z')
+	if !isASCIILetter && first != '_' {
+		t.Errorf("PopupSentinelEnv %q must start with an ASCII letter or underscore", PopupSentinelEnv)
 	}
 }
 
-// fakeTmux writes a minimal shell script to dir/tmux that exits with the
-// given code and returns the directory prepended PATH.
+// fakeTmux writes a shell script to dir/tmux that:
+//   - responds to "list-commands" by printing "display-popup" and exiting 0
+//   - responds to any other subcommand by exiting with exitCode
+//
+// It returns the directory prepended to PATH so exec.LookPath finds it first.
 func fakeTmux(t *testing.T, exitCode int) string {
 	t.Helper()
 	dir := t.TempDir()
-	script := []byte("#!/bin/sh\nexit " + itoa(exitCode) + "\n")
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"  list-commands) printf 'display-popup\\n'; exit 0 ;;\n" +
+		"  *) exit " + itoa(exitCode) + " ;;\n" +
+		"esac\n"
 	path := filepath.Join(dir, "tmux")
-	if err := os.WriteFile(path, script, 0o755); err != nil {
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatalf("fakeTmux: write script: %v", err)
 	}
 	return dir + string(filepath.ListSeparator) + os.Getenv("PATH")
@@ -117,6 +129,22 @@ func TestLaunchTmuxPopup_NoTmux(t *testing.T) {
 	code, err := LaunchTmuxPopup([]string{"test-arg"})
 	if err == nil {
 		t.Errorf("expected error when tmux is not on PATH, got nil (code %d)", code)
+	}
+}
+
+func TestLaunchTmuxPopup_NoDisplayPopup(t *testing.T) {
+	// A fake tmux that is present but does not advertise display-popup in
+	// list-commands output (simulates tmux < 3.2). LaunchTmuxPopup should
+	// return a non-nil error so the caller falls through to pager mode.
+	dir := t.TempDir()
+	script := []byte("#!/bin/sh\ncase \"$1\" in\n  list-commands) exit 0 ;;\n  *) exit 0 ;;\nesac\n")
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), script, 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	t.Setenv("PATH", dir+string(filepath.ListSeparator)+os.Getenv("PATH"))
+	code, err := LaunchTmuxPopup([]string{})
+	if err == nil {
+		t.Errorf("expected error when display-popup not available, got nil (code %d)", code)
 	}
 }
 

--- a/internal/term/popup_test.go
+++ b/internal/term/popup_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Adam Poulemanos
+//
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package term
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShellQuote(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"hello", "'hello'"},
+		{"hello world", "'hello world'"},
+		{"it's", `'it'\''s'`},
+		{"", "''"},
+		{"a'b'c", `'a'\''b'\''c'`},
+		{"/usr/bin/spy", "'/usr/bin/spy'"},
+		{"--flag=value", "'--flag=value'"},
+	}
+	for _, tc := range cases {
+		got := shellQuote(tc.in)
+		if got != tc.want {
+			t.Errorf("shellQuote(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestShellQuote_SafeForShell(t *testing.T) {
+	// Verify that single-quoting a string with embedded single quotes
+	// produces a valid shell token by checking that the output only ever
+	// contains the '\'' escape and is properly bookended.
+	tricky := "don't stop; rm -rf / # evil"
+	q := shellQuote(tricky)
+	if !strings.HasPrefix(q, "'") {
+		t.Errorf("shellQuote result must start with single quote, got %q", q)
+	}
+	// The result must not contain an unescaped literal single quote
+	// (i.e. a ' that isn't part of the '\'' escape sequence).
+	stripped := strings.ReplaceAll(q, `'\''`, "")
+	stripped = strings.TrimPrefix(stripped, "'")
+	stripped = strings.TrimSuffix(stripped, "'")
+	if strings.Contains(stripped, "'") {
+		t.Errorf("shellQuote result contains unescaped single quote: %q", q)
+	}
+}
+
+func TestPopupSentinelEnv(t *testing.T) {
+	// Constant must not be empty and must be a valid env var name.
+	if PopupSentinelEnv == "" {
+		t.Fatal("PopupSentinelEnv must not be empty")
+	}
+	for _, c := range PopupSentinelEnv {
+		if !((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+			t.Errorf("PopupSentinelEnv %q contains non-identifier character %q", PopupSentinelEnv, c)
+		}
+	}
+}

--- a/tests/integration/pty.go
+++ b/tests/integration/pty.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/creack/pty"
+
+	"github.com/knitli/spy/internal/term"
 )
 
 // AltScreenEnter is the canonical CSI sequence Bubble Tea emits when
@@ -480,9 +482,9 @@ func moduleRoot(t *testing.T) string {
 // PTY tests that have no real tmux session; _SPY_POPUP_ACTIVE is the
 // internal sentinel that prevents recursive popup launches.
 var stripFromTests = map[string]struct{}{
-	"TMUX":              {},
-	"TMUX_PANE":         {},
-	"_SPY_POPUP_ACTIVE": {},
+	"TMUX":                {},
+	"TMUX_PANE":           {},
+	term.PopupSentinelEnv: {},
 }
 
 // mergeEnv composes the spawned process environment from the parent

--- a/tests/integration/pty.go
+++ b/tests/integration/pty.go
@@ -474,22 +474,35 @@ func moduleRoot(t *testing.T) string {
 	}
 }
 
+// stripFromTests lists environment variables that should never be
+// inherited by test subprocesses unless the test explicitly sets them.
+// TMUX and TMUX_PANE would trigger spy's tmux popup re-launch even in
+// PTY tests that have no real tmux session; _SPY_POPUP_ACTIVE is the
+// internal sentinel that prevents recursive popup launches.
+var stripFromTests = map[string]struct{}{
+	"TMUX":              {},
+	"TMUX_PANE":         {},
+	"_SPY_POPUP_ACTIVE": {},
+}
+
 // mergeEnv composes the spawned process environment from the parent
 // environment plus `env`. Keys in `env` override the inherited value.
-// A nil `env` yields the parent environment unchanged.
+// Variables in [stripFromTests] are removed unless the caller re-adds
+// them in `env`. A nil `env` still applies the strip list.
 func mergeEnv(env map[string]string) []string {
 	parent := os.Environ()
-	if len(env) == 0 {
-		return parent
-	}
-	// Drop any inherited entry the caller is overriding.
 	out := make([]string, 0, len(parent)+len(env))
 	for _, kv := range parent {
 		key := kv
 		if i := indexByte(kv, '='); i >= 0 {
 			key = kv[:i]
 		}
+		// Skip variables the caller is overriding or that are stripped
+		// from the test environment by default.
 		if _, ok := env[key]; ok {
+			continue
+		}
+		if _, strip := stripFromTests[key]; strip {
 			continue
 		}
 		out = append(out, kv)


### PR DESCRIPTION
## Summary

- **`internal/term/popup.go`** — new `LaunchTmuxPopup` function; builds a POSIX-quoted shell command with `_SPY_POPUP_ACTIVE=1` sentinel and hands it to `tmux display-popup -E -w 100% -h 100%`
- **`cmd/spy/main.go`** — dispatch block after help/version, before `term.Detect`; fires when `$TMUX` is set + stdin is a TTY + not already in popup + `--no-popup` not passed; falls through silently on tmux failure
- **`cmd/spy/flags.go`** — `--no-popup` flag to opt out per-invocation (permanent: `alias spy='spy --no-popup'`)
- **`tests/integration/pty.go`** — `mergeEnv` strips `TMUX`, `TMUX_PANE`, and `_SPY_POPUP_ACTIVE` from inherited test env so PTY tests are not broken when the developer runs them inside tmux
- **`README.md`** — new "Multiplexer integration" section: tmux auto-popup, opt-out, WezTerm shell function + Lua keybinding snippet, Kitty overlay config

## Behaviour

```
# inside any tmux pane (any size):
spy README.md   →  full-screen popup appears, quit dismisses it

# opt out:
spy --no-popup README.md   →  runs in current pane as before

# piped input is unaffected (tmux popup can't inherit a pipe):
git diff | spy   →  runs in current pane as before
```

Requires **tmux 3.2+** (2020). Falls back to normal pager mode if tmux is not found or `display-popup` fails.

## Test plan

- [ ] Run `go test ./...` — all green including integration + perf suites
- [ ] Manual: `spy README.md` inside a tmux session with multiple panes — popup covers all panes at 100%×100%
- [ ] Manual: `spy --no-popup README.md` — runs in current pane
- [ ] Manual: `git diff | spy` — runs in current pane (stdin is a pipe, popup skipped)
- [ ] Manual: outside tmux — runs in current terminal normally